### PR TITLE
Features/config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,64 @@
+template = "honeytrap"
+
+[delays]
+push_every = "10s"
+freeze_every = "10s"
+stop_every = "30s"
+
+[[channels]]
+name = "honeytrap"
+host = "http://api.honeytrap.io/"
+token = "b0b6e462-ef0b-11e6-abc7-0fb6247f5820"
+
+[[channels]]
+name = "slack"
+host = "https://hooks.slack.com/services/"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
+
+[channels.fields]
+sensors = "^ping"
+container_id = "bob"
+sensors_id = "^TUH43-"
+category_id = "^21223-"
+
+[[channels.channels]]
+field = "sensors"
+value = "^ping"
+channel = "ping-channel"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
+
+[[channels.channels]]
+field = "categories"
+value = "^WebRTC"
+channel = "webrtc-channel"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
+
+[[channels.channels]]
+field = "session_id"
+value = "32121-"
+channel = "sessions-channel"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
+
+[[channels.channels]]
+field = "container_id"
+value = "32121-"
+channel = "containers-channel"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
+
+[housekeeper]
+every = "10s"
+
+[[services]]
+service = "http"
+enabled = "true"
+port = ":8080"
+
+[[services]]
+service = "ssh"
+port = ":8022"
+banner = "SSH-2.0-OpenSSH_6.6.1p1 2020Ubuntu-2ubuntu2"
+#key = "./perm/perms"
+
+[[logging]]
+output = "stdout"
+level = "debug"

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -25,21 +25,25 @@ category_id = "^21223-"
 field = "sensors"
 value = "^ping"
 channel = "ping-channel"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
 
 [[channels.channels]]
 field = "categories"
 value = "^WebRTC"
 channel = "webrtc-channel"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
 
 [[channels.channels]]
 field = "session_id"
 value = "32121-"
 channel = "sessions-channel"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
 
 [[channels.channels]]
 field = "container_id"
 value = "32121-"
 channel = "containers-channel"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
 
 [housekeeper]
 every = "10s"

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -10,6 +10,11 @@ name = "honeytrap"
 host = "http://api.honeytrap.io/"
 token = "b0b6e462-ef0b-11e6-abc7-0fb6247f5820"
 
+[[channels]]
+name = "slack"
+host = "https://hooks.slack.com/services/"
+token = "T06M39MCM/B4GHZCCFP/VOOepdacxW9HG60eDfoFBiMF"
+
 [housekeeper]
 every = "10s"
 

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -13,7 +13,10 @@ token = "b0b6e462-ef0b-11e6-abc7-0fb6247f5820"
 [[channels]]
 name = "slack"
 host = "https://hooks.slack.com/services/"
-token = "T06M39MCM/B4GHZCCFP/VOOepdacxW9HG60eDfoFBiMF"
+token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
+
+[channels.fields]
+sensors = "^ping"
 
 [housekeeper]
 every = "10s"

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -17,6 +17,29 @@ token = "KUL6M39MCM/YU16GBD/VOOW9HG60eDfoFBiMF"
 
 [channels.fields]
 sensors = "^ping"
+container_id = "bob"
+sensors_id = "^TUH43-"
+category_id = "^21223-"
+
+[[channels.channels]]
+field = "sensors"
+value = "^ping"
+channel = "ping-channel"
+
+[[channels.channels]]
+field = "categories"
+value = "^WebRTC"
+channel = "webrtc-channel"
+
+[[channels.channels]]
+field = "session_id"
+value = "32121-"
+channel = "sessions-channel"
+
+[[channels.channels]]
+field = "container_id"
+value = "32121-"
+channel = "containers-channel"
 
 [housekeeper]
 every = "10s"

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ type (
 	Folders struct {
 		Data string `toml:"data"`
 	}
+
 	Config struct {
 		Token       string      `toml:"token"`
 		Template    string      `toml:"template"`

--- a/pushers/message/message.go
+++ b/pushers/message/message.go
@@ -1,0 +1,11 @@
+package message
+
+// Message defines a struct which contains specific data relating to
+// different messages to provide Push notifications for the pusher api.
+type PushMessage struct {
+	Sensor      string
+	Category    string
+	SessionID   string
+	ContainerID string
+	Data        interface{}
+}

--- a/pushers/slack/slack.go
+++ b/pushers/slack/slack.go
@@ -1,0 +1,157 @@
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/honeytrap/honeytrap/pushers"
+	"github.com/op/go-logging"
+)
+
+var log = logging.MustGetLogger("honeytrap:channels:slack")
+var _ = pushers.Register("slack", NewMessageChannel())
+
+// MessageChannel provides a struct which holds the configured means by which
+// slack notifications are sent into giving slack groups and channels.
+type MessageChannel struct {
+	client *http.Client
+	host   string
+	token  string
+}
+
+// NewMessageChannel returns a new instance of a slack MessageChannel.
+func NewMessageChannel() pushers.ChannelFunc {
+	return func(conf map[string]interface{}) (pushers.Channel, error) {
+		var client http.Client
+		client.Transport = &http.Transport{MaxIdleConnsPerHost: 5}
+		client.Timeout = 20 * time.Second
+
+		var host string
+		var token string
+
+		var ok bool
+		if host, ok = conf["host"].(string); !ok {
+			return nil, errors.New("Host not provided for Slack Channel")
+		}
+
+		if token, ok = conf["token"].(string); !ok {
+			return nil, errors.New("Token not provided for slack Channel")
+		}
+
+		return &MessageChannel{
+			client: &client,
+			host:   host,
+			token:  token,
+		}, nil
+	}
+}
+
+type newSlackMessage struct {
+	Text        string               `json:"text"`
+	Attachments []newSlackAttachment `json:"attachments"`
+}
+
+type newSlackField struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+	Short bool   `json:"short"`
+}
+
+type newSlackAttachment struct {
+	Title     string          `json:"title"`
+	Author    string          `json:"author_name,omitempty"`
+	Fallback  string          `json:"fallback,omitempty"`
+	Fields    []newSlackField `json:"fields"`
+	Text      string          `json:"text"`
+	Timestamp int64           `json:"ts"`
+}
+
+// Send delivers the giving push messages to the required slack channel.
+// TODO: Ask if Send shouldnt return an error to allow proper delivery validation.
+func (mc MessageChannel) Send(messages []*pushers.PushMessage) {
+	for _, message := range messages {
+
+		// TODO: Implement message filtering through channel regexp.
+
+		//Attempt to encode message body first and if failed, log and continue.
+		messageBuffer := new(bytes.Buffer)
+		if err := json.NewEncoder(messageBuffer).Encode(message.Data); err != nil {
+			log.Errorf("SlackMessageChannel: Error encoding data: %q", err.Error())
+			continue
+		}
+
+		// Create the appropriate fields for the giving slack message.
+		var fields []newSlackField
+
+		fields = append(fields, newSlackField{
+			Title: "Sensor",
+			Value: message.Sensor,
+			Short: true,
+		})
+
+		fields = append(fields, newSlackField{
+			Title: "Category",
+			Value: message.Category,
+			Short: true,
+		})
+
+		fields = append(fields, newSlackField{
+			Title: "Session ID",
+			Value: message.SessionID,
+			Short: true,
+		})
+
+		fields = append(fields, newSlackField{
+			Title: "Container ID",
+			Value: message.ContainerID,
+			Short: true,
+		})
+
+		var slackMessage newSlackMessage
+		slackMessage.Text = fmt.Sprintf("New Sensor Message from %q with Category %q", message.Sensor, message.Category)
+		slackMessage.Attachments = append(slackMessage.Attachments, newSlackAttachment{
+			Title:    "Sensor Data",
+			Author:   "HoneyTrap",
+			Fields:   fields,
+			Text:     string(messageBuffer.Bytes()),
+			Fallback: fmt.Sprintf("New SensorMessage (Sensor: %q, Category: %q, Session: %q, Container: %q). Check Slack for more", message.Sensor, message.Category, message.SessionID, message.ContainerID),
+		})
+
+		slackMessageBuffer := new(bytes.Buffer)
+		if err := json.NewEncoder(slackMessageBuffer).Encode(slackMessage); err != nil {
+			log.Errorf("SlackMessageChannel: Error encoding new SlackMessage: %+q", err)
+			continue
+		}
+
+		reqURL := fmt.Sprintf("%s/%s", mc.host, mc.token)
+		req, err := http.NewRequest("POST", reqURL, slackMessageBuffer)
+		if err != nil {
+			log.Errorf("SlackMessageChannel: Error while creating new request object: %+q", err)
+			continue
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+
+		res, err := mc.client.Do(req)
+		if err != nil {
+			log.Errorf("SlackMessageChannel: Error while making request to endpoint(%q): %q", reqURL, err.Error())
+			continue
+		}
+
+		// Though we expect slack not to deliver any messages to us but to be safe
+		// discard and close body.
+		io.Copy(ioutil.Discard, res.Body)
+		res.Body.Close()
+
+		if res.StatusCode != http.StatusCreated {
+			log.Errorf("SlackMessageChannel: API Response with unexpected Status Code[%d] to endpoint: %q", res.StatusCode, reqURL)
+			continue
+		}
+	}
+}

--- a/pushers/slack/slack.go
+++ b/pushers/slack/slack.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/honeytrap/honeytrap/pushers"
@@ -23,6 +24,7 @@ type MessageChannel struct {
 	client *http.Client
 	host   string
 	token  string
+	fields map[string]*regexp.Regexp
 }
 
 // NewMessageChannel returns a new instance of a slack MessageChannel.

--- a/pushers/slack/slack_test.go
+++ b/pushers/slack/slack_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/honeytrap/honeytrap/pushers"
+	"github.com/honeytrap/honeytrap/pushers/message"
 	"github.com/honeytrap/honeytrap/pushers/slack"
 )
 
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	blueChip = &pushers.PushMessage{
+	blueChip = &message.PushMessage{
 		Sensor:      "BlueChip",
 		Category:    "Chip Integrated",
 		SessionID:   "4334334-3433434-34343-FUD",
@@ -27,7 +27,7 @@ var (
 		Data:        "Hello World!",
 	}
 
-	ping = &pushers.PushMessage{
+	ping = &message.PushMessage{
 		Sensor:      "Ping",
 		Category:    "Ping Notificiation",
 		SessionID:   "4334334-3433434-34343-FUD",
@@ -35,7 +35,7 @@ var (
 		Data:        "Hello World!",
 	}
 
-	crum = &pushers.PushMessage{
+	crum = &message.PushMessage{
 		Sensor:      "Crum Stream",
 		Category:    "WebRTC Crum Stream",
 		SessionID:   "4334334-3433434-34343-FUD",
@@ -87,11 +87,11 @@ func TestSlackPusher(t *testing.T) {
 	t.Logf("Given the need to post messages to Slack Channels ")
 	{
 
-		newSlackChannel := slack.NewMessageChannel()
+		var channel slack.MessageChannel
 
 		t.Logf("\tWhen provided the invalid Slack Webhook credentials")
 		{
-			_, err := newSlackChannel(map[string]interface{}{
+			err := channel.UnmarshalConfig(map[string]interface{}{
 				"hosts":  "slack.com/services/",
 				"tokens": "343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF",
 			})
@@ -111,7 +111,7 @@ func TestSlackPusher(t *testing.T) {
 			server := httptest.NewServer(&service)
 			host := server.URL + "/services"
 
-			channel, err := newSlackChannel(map[string]interface{}{
+			err := channel.UnmarshalConfig(map[string]interface{}{
 				"host":  host,
 				"token": "343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF",
 			})
@@ -121,7 +121,7 @@ func TestSlackPusher(t *testing.T) {
 			}
 			t.Logf("\t%s\t Should have successfully created new MessageChannel.", passed)
 
-			channel.Send([]*pushers.PushMessage{blueChip})
+			channel.Send([]*message.PushMessage{blueChip})
 
 			response := make(map[string]interface{})
 			if err := json.NewDecoder(&service.Body).Decode(&response); err != nil {
@@ -166,7 +166,7 @@ func TestSlackPusher(t *testing.T) {
 			server := httptest.NewServer(&service)
 			host := server.URL + "/services"
 
-			channel, err := newSlackChannel(map[string]interface{}{
+			err := channel.UnmarshalConfig(map[string]interface{}{
 				"host":  host,
 				"token": "343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF",
 				"fields": map[string]interface{}{
@@ -182,7 +182,7 @@ func TestSlackPusher(t *testing.T) {
 
 			response := make(map[string]interface{})
 
-			channel.Send([]*pushers.PushMessage{ping, crum})
+			channel.Send([]*message.PushMessage{ping, crum})
 			if err := json.NewDecoder(&service.Body).Decode(&response); err != nil {
 				t.Fatalf("\t%s\t Should have successfully failed to unmarshalled empty body: %q.", failed, err.Error())
 			}
@@ -190,7 +190,7 @@ func TestSlackPusher(t *testing.T) {
 
 			response = make(map[string]interface{})
 
-			channel.Send([]*pushers.PushMessage{crum})
+			channel.Send([]*message.PushMessage{crum})
 			if err := json.NewDecoder(&service.Body).Decode(&response); err != nil {
 				t.Fatalf("\t%s\t Should have successfully failed to unmarshalled empty body: %q.", failed, err.Error())
 			}
@@ -205,7 +205,7 @@ func TestSlackPusher(t *testing.T) {
 			server := httptest.NewServer(&service)
 			host := server.URL + "/services"
 
-			channel, err := newSlackChannel(map[string]interface{}{
+			err := channel.UnmarshalConfig(map[string]interface{}{
 				"host":  host,
 				"token": "343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF",
 				"fields": map[string]interface{}{
@@ -232,7 +232,7 @@ func TestSlackPusher(t *testing.T) {
 			}
 			t.Logf("\t%s\t Should have successfully created new MessageChannel.", passed)
 
-			channel.Send([]*pushers.PushMessage{ping})
+			channel.Send([]*message.PushMessage{ping})
 
 			pingResponse := make(map[string]interface{})
 			if err := json.NewDecoder(&service.Body).Decode(&pingResponse); err != nil {
@@ -250,7 +250,7 @@ func TestSlackPusher(t *testing.T) {
 			}
 			t.Logf("\t%s\t Should have successfully matched request toekn for ping response.", passed)
 
-			channel.Send([]*pushers.PushMessage{crum})
+			channel.Send([]*message.PushMessage{crum})
 
 			crumResponse := make(map[string]interface{})
 			if err := json.NewDecoder(&service.Body).Decode(&crumResponse); err != nil {

--- a/pushers/slack/slack_test.go
+++ b/pushers/slack/slack_test.go
@@ -1,0 +1,62 @@
+package slack_test
+
+import (
+	"testing"
+
+	"github.com/honeytrap/honeytrap/pushers"
+	"github.com/honeytrap/honeytrap/pushers/slack"
+)
+
+const (
+	passed = "\u2713"
+	failed = "\u2717"
+)
+
+// TestSlackPusher validates the operational correctness of the
+// slack message channel which allows us delivery messages to slack channels
+// as describe from the provided configuration.
+func TestSlackPusher(t *testing.T) {
+
+	t.Logf("Given the need to post messages to Slack Channels ")
+	{
+
+		newSlackChannel := slack.NewMessageChannel()
+
+		t.Logf("\tWhen provided the invalid Slack Webhook credentials")
+		{
+			_, err := newSlackChannel(map[string]interface{}{
+				"hosts":  "https://hooks.slack.com/services/",
+				"tokens": "T06M39MCM/B4GHZCCFP/VOOepdacxW9HG60eDfoFBiMF",
+			})
+
+			if err == nil {
+				t.Fatalf("\t%s\t Should have sucessfully failed to create a new MessageChannel: %q.", failed, err.Error())
+			}
+			t.Logf("\t%s\t Should have sucessfully failed to create a new MessageChannel.", passed)
+		}
+
+		t.Logf("\tWhen provided the correct Slack Webhook credentials")
+		{
+			channel, err := newSlackChannel(map[string]interface{}{
+				"host":  "https://hooks.slack.com/services/",
+				"token": "T06M39MCM/B4GHZCCFP/VOOepdacxW9HG60eDfoFBiMF",
+			})
+
+			if err != nil {
+				t.Fatalf("\t%s\t Should have sucessfully created new MessageChannel: %q.", failed, err.Error())
+			}
+			t.Logf("\t%s\t Should have sucessfully created new MessageChannel.", passed)
+
+			channel.Send([]*pushers.PushMessage{
+				&pushers.PushMessage{
+					Sensor:      "BlueChip",
+					Category:    "Chip Integrated",
+					SessionID:   "4334334-3433434-34343-FUD",
+					ContainerID: "56454-5454UDF-2232UI-34FGHU",
+					Data:        "Hello World!",
+				},
+			})
+		}
+
+	}
+}

--- a/pushers/slack/slack_test.go
+++ b/pushers/slack/slack_test.go
@@ -1,6 +1,8 @@
 package slack_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/honeytrap/honeytrap/pushers"
@@ -11,6 +13,17 @@ const (
 	passed = "\u2713"
 	failed = "\u2717"
 )
+
+type slackService struct{}
+
+func (slackService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/services/343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF" {
+		w.WriteHeader(404)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
 
 // TestSlackPusher validates the operational correctness of the
 // slack message channel which allows us delivery messages to slack channels
@@ -25,8 +38,8 @@ func TestSlackPusher(t *testing.T) {
 		t.Logf("\tWhen provided the invalid Slack Webhook credentials")
 		{
 			_, err := newSlackChannel(map[string]interface{}{
-				"hosts":  "https://hooks.slack.com/services/",
-				"tokens": "T06M39MCM/B4GHZCCFP/VOOepdacxW9HG60eDfoFBiMF",
+				"hosts":  "slack.com/services/",
+				"tokens": "343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF",
 			})
 
 			if err == nil {
@@ -37,9 +50,14 @@ func TestSlackPusher(t *testing.T) {
 
 		t.Logf("\tWhen provided the correct Slack Webhook credentials")
 		{
+
+			// Setup test server for mocking
+			server := httptest.NewServer(slackService{})
+			host := server.URL + "/services"
+
 			channel, err := newSlackChannel(map[string]interface{}{
-				"host":  "https://hooks.slack.com/services/",
-				"token": "T06M39MCM/B4GHZCCFP/VOOepdacxW9HG60eDfoFBiMF",
+				"host":  host,
+				"token": "343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF",
 			})
 
 			if err != nil {

--- a/pushers/slack/slack_test.go
+++ b/pushers/slack/slack_test.go
@@ -1,6 +1,9 @@
 package slack_test
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,14 +17,43 @@ const (
 	failed = "\u2717"
 )
 
-type slackService struct{}
+var (
+	blueChip = &pushers.PushMessage{
+		Sensor:      "BlueChip",
+		Category:    "Chip Integrated",
+		SessionID:   "4334334-3433434-34343-FUD",
+		ContainerID: "56454-5454UDF-2232UI-34FGHU",
+		Data:        "Hello World!",
+	}
 
-func (slackService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ping = &pushers.PushMessage{
+		Sensor:      "Ping",
+		Category:    "Ping Notificiation",
+		SessionID:   "4334334-3433434-34343-FUD",
+		ContainerID: "56454-5454UDF-2232UI-34FGHU",
+		Data:        "Hello World!",
+	}
+
+	crum = &pushers.PushMessage{
+		Sensor:      "Crum Stream",
+		Category:    "WebRTC Crum Stream",
+		SessionID:   "4334334-3433434-34343-FUD",
+		ContainerID: "56454-5454UDF-2232UI-34FGHU",
+		Data:        "Hello World!",
+	}
+)
+
+type slackService struct {
+	Body bytes.Buffer
+}
+
+func (s *slackService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/services/343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF" {
 		w.WriteHeader(404)
 		return
 	}
 
+	io.Copy(&s.Body, r.Body)
 	w.WriteHeader(http.StatusCreated)
 }
 
@@ -43,16 +75,18 @@ func TestSlackPusher(t *testing.T) {
 			})
 
 			if err == nil {
-				t.Fatalf("\t%s\t Should have sucessfully failed to create a new MessageChannel: %q.", failed, err.Error())
+				t.Fatalf("\t%s\t Should have successfully failed to create new MessageChannel: %q.", failed, err.Error())
 			}
-			t.Logf("\t%s\t Should have sucessfully failed to create a new MessageChannel.", passed)
+			t.Logf("\t%s\t Should have successfully failed to create new MessageChannel.", passed)
 		}
 
 		t.Logf("\tWhen provided the correct Slack Webhook credentials")
 		{
 
-			// Setup test server for mocking
-			server := httptest.NewServer(slackService{})
+			// Setup test service and server for mocking.
+			var service slackService
+
+			server := httptest.NewServer(&service)
 			host := server.URL + "/services"
 
 			channel, err := newSlackChannel(map[string]interface{}{
@@ -61,19 +95,84 @@ func TestSlackPusher(t *testing.T) {
 			})
 
 			if err != nil {
-				t.Fatalf("\t%s\t Should have sucessfully created new MessageChannel: %q.", failed, err.Error())
+				t.Fatalf("\t%s\t Should have successfully created new MessageChannel: %q.", failed, err.Error())
 			}
-			t.Logf("\t%s\t Should have sucessfully created new MessageChannel.", passed)
+			t.Logf("\t%s\t Should have successfully created new MessageChannel.", passed)
 
-			channel.Send([]*pushers.PushMessage{
-				&pushers.PushMessage{
-					Sensor:      "BlueChip",
-					Category:    "Chip Integrated",
-					SessionID:   "4334334-3433434-34343-FUD",
-					ContainerID: "56454-5454UDF-2232UI-34FGHU",
-					Data:        "Hello World!",
+			channel.Send([]*pushers.PushMessage{blueChip})
+
+			response := make(map[string]interface{})
+			if err := json.NewDecoder(&service.Body).Decode(&response); err != nil {
+				t.Fatalf("\t%s\t Should have successfully unmarshalled service body: %q.", failed, err.Error())
+			}
+			t.Logf("\t%s\t Should have successfully unmarshalled service body.", passed)
+
+			attachments, ok := response["attachments"].([]interface{})
+			if !ok {
+				t.Fatalf("\t%s\t Should have successfully retrieved attachments.", failed)
+			}
+			t.Logf("\t%s\t Should have successfully retrieved attachments.", passed)
+
+			if len(attachments) < 1 {
+				t.Fatalf("\t%s\t Should have successfully retrieved 1 attachments.", failed)
+			}
+			t.Logf("\t%s\t Should have successfully retrieved 1 attachments.", passed)
+
+			attached, ok := attachments[0].(map[string]interface{})
+			if !ok {
+				t.Fatalf("\t%s\t Should have successfully retrieved first attachement.", failed)
+			}
+			t.Logf("\t%s\t Should have successfully retrieved first attachement.", passed)
+
+			fields, ok := attached["fields"].([]interface{})
+			if !ok {
+				t.Fatalf("\t%s\t Should have successfully retrieved fields.", failed)
+			}
+			t.Logf("\t%s\t Should have successfully retrieved fields.", passed)
+
+			if len(fields) < 4 {
+				t.Fatalf("\t%s\t Should have successfully retrieved 4 fields.", failed)
+			}
+			t.Logf("\t%s\t Should have successfully retrieved 4 fields.", passed)
+		}
+
+		t.Logf("\tWhen provided Slack Webhook credentials with method filters")
+		{
+			// Setup test service and server for mocking.
+			var service slackService
+
+			server := httptest.NewServer(&service)
+			host := server.URL + "/services"
+
+			channel, err := newSlackChannel(map[string]interface{}{
+				"host":  host,
+				"token": "343HJUYFHGT/B4545IO/VOOepdacxW9HG60eDfoFBiMF",
+				"fields": map[string]interface{}{
+					"sensor":   "[^ping]",
+					"category": "[^WebRTC]",
 				},
 			})
+
+			if err != nil {
+				t.Fatalf("\t%s\t Should have successfully created new MessageChannel: %q.", failed, err.Error())
+			}
+			t.Logf("\t%s\t Should have successfully created new MessageChannel.", passed)
+
+			response := make(map[string]interface{})
+
+			channel.Send([]*pushers.PushMessage{ping, crum})
+			if err := json.NewDecoder(&service.Body).Decode(&response); err != nil {
+				t.Fatalf("\t%s\t Should have successfully failed to unmarshalled empty body: %q.", failed, err.Error())
+			}
+			t.Logf("\t%s\t Should have successfully failed to unmarshalled empty body.", passed)
+
+			response = make(map[string]interface{})
+
+			channel.Send([]*pushers.PushMessage{crum})
+			if err := json.NewDecoder(&service.Body).Decode(&response); err != nil {
+				t.Fatalf("\t%s\t Should have successfully failed to unmarshalled empty body: %q.", failed, err.Error())
+			}
+			t.Logf("\t%s\t Should have successfully failed to unmarshalled empty body.", passed)
 		}
 
 	}

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -16,6 +16,7 @@ import (
 	pushers "github.com/honeytrap/honeytrap/pushers"
 	_ "github.com/honeytrap/honeytrap/pushers/elasticsearch"
 	_ "github.com/honeytrap/honeytrap/pushers/honeytrap"
+	_ "github.com/honeytrap/honeytrap/pushers/slack"
 
 	utils "github.com/honeytrap/honeytrap/utils"
 

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -14,8 +14,8 @@ import (
 	_ "github.com/honeytrap/honeytrap/proxies/ssh"
 
 	pushers "github.com/honeytrap/honeytrap/pushers"
-	_ "github.com/honeytrap/honeytrap/pushers/elasticsearch"
-	_ "github.com/honeytrap/honeytrap/pushers/honeytrap"
+	// _ "github.com/honeytrap/honeytrap/pushers/elasticsearch"
+	// _ "github.com/honeytrap/honeytrap/pushers/honeytrap"
 	_ "github.com/honeytrap/honeytrap/pushers/slack"
 
 	utils "github.com/honeytrap/honeytrap/utils"


### PR DESCRIPTION
This PR makes quite the changes and abstracts configuration into the individual pushers themselves.


## NOTE:
I thought alot about the change I made in removing the registry and moving the main dependency `PushMessage` into another package. It bothered abit if we were unnecessary moving it outside, and if better yet to put it in the `api` pkg, but I felt it suited more without having to import the `api` details as well. Of course, this choice can be changed if we feel the previous system was still better with function makers and the internals doing the proper calls to have each pusher load it's own configuration or move the `PushMessage` into `api`.