### PR TITLE
Resolving Lint errors with director pkg

### DIFF
--- a/director/director_linux.go
+++ b/director/director_linux.go
@@ -8,17 +8,17 @@ import (
 	"net"
 	"sync"
 
-	"github.com/op/go-logging"
-
 	config "github.com/honeytrap/honeytrap/config"
 	providers "github.com/honeytrap/honeytrap/providers"
 	pushers "github.com/honeytrap/honeytrap/pushers"
+	logging "github.com/op/go-logging"
 
 	lxc "gopkg.in/lxc/go-lxc.v2"
 )
 
 var log = logging.MustGetLogger("honeytrap:director")
 
+// Director defines a struct which handles the management of registered containers.
 type Director struct {
 	containers map[string]providers.Container
 	m          sync.Mutex
@@ -26,6 +26,7 @@ type Director struct {
 	provider   providers.Provider
 }
 
+// New returns a new instance of a Director.
 func New(conf *config.Config) *Director {
 	pusher := pushers.NewRecordPusher(conf)
 
@@ -38,7 +39,11 @@ func New(conf *config.Config) *Director {
 	d.registerContainers()
 
 	// TODO: do we need this pusher?, use default pushers, PushData or something
-	go pusher.Run()
+	go func() {
+		if err := pusher.Run(); err != nil {
+			log.Errorf("Error during Run call for pusher: %s", err.Error())
+		}
+	}()
 
 	return d
 }
@@ -54,7 +59,7 @@ func (d *Director) registerContainers() {
 
 		container, err := d.NewContainer(name)
 		if err != nil {
-			log.Error("Error during container registration: %s", err.Error())
+			log.Errorf("Error during container registration: %s", err.Error())
 			continue
 		}
 
@@ -69,16 +74,22 @@ func (d *Director) getName(c net.Conn) (string, error) {
 	}
 
 	hasher := md5.New()
-	hasher.Write([]byte(fmt.Sprintf("%s%s", rhost, d.config.Token)))
+	if _, err := hasher.Write([]byte(fmt.Sprintf("%s%s", rhost, d.config.Token))); err != nil {
+		log.Errorf("Error during hasher.Write call: %s", err.Error())
+		return "", err
+	}
+
 	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
 }
 
+// NewContainer returns a new providers.Container instance from the provided internal providers.
 func (d *Director) NewContainer(name string) (providers.Container, error) {
 	return d.provider.NewContainer(
 		name,
 	)
 }
 
+// GetContainer returns a provider.Container instance from those already created on the director.
 func (d *Director) GetContainer(c net.Conn) (providers.Container, error) {
 	d.m.Lock()
 	defer d.m.Unlock()


### PR DESCRIPTION
PR provides resolution to linting errors with the exceptions of the usage of the `md5` crypto package and the error related to mutex copying. 

- Resolve error with `director/` package
- Resolve of error logging



Issue: #16 