### PR TITLE
Add honeytrap/golxc pkg

### DIFF
--- a/director/director_linux.go
+++ b/director/director_linux.go
@@ -8,13 +8,12 @@ import (
 	"net"
 	"sync"
 
-	"github.com/op/go-logging"
-
 	config "github.com/honeytrap/honeytrap/config"
 	providers "github.com/honeytrap/honeytrap/providers"
 	pushers "github.com/honeytrap/honeytrap/pushers"
 
-	lxc "gopkg.in/lxc/go-lxc.v2"
+	lxc "github.com/honeytrap/golxc"
+	logging "github.com/op/go-logging"
 )
 
 var log = logging.MustGetLogger("honeytrap:director")

--- a/providers/lxccontainer.go
+++ b/providers/lxccontainer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/honeytrap/honeytrap/pushers"
 	"github.com/honeytrap/honeytrap/sniffer"
 
-	lxc "gopkg.in/lxc/go-lxc.v2"
+	lxc "github.com/honeytrap/golxc"
 )
 
 /*


### PR DESCRIPTION
PR changes the usage of the `gopkg.in/go-lxc.v2` to the internal lxc package `honeytrap/golxc`.

We made this change due to the need of fixing certain errors that occur within the `go-lxc.v2` package:

- Copying of mutex on calls to `Containers()`.



Issue: #16 