### PR TITLE
Add New Event API to proxies

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,18 +3,20 @@ package cmd
 import (
 	"fmt"
 
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/fatih/color"
 	"github.com/honeytrap/honeytrap/config"
 	"github.com/honeytrap/honeytrap/server"
 	"github.com/minio/cli"
 	"github.com/op/go-logging"
 	"github.com/pkg/profile"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
+// Version defines the version number for the cli.
 var Version = "0.1"
 
 var helpTemplate = `NAME:
@@ -55,10 +57,12 @@ var globalFlags = []cli.Flag{
 	cli.BoolFlag{Name: "profiler", Usage: "Enable web profiler"},
 }
 
+// Cmd defines a struct for defining a command.
 type Cmd struct {
 	*cli.App
 }
 
+// VersionAction defines the action called when seeking the Version detail.
 func VersionAction(c *cli.Context) {
 	fmt.Println(color.YellowString(fmt.Sprintf("Honeytrap: The ultimate honeypot framework.")))
 }
@@ -78,7 +82,7 @@ func serve(c *cli.Context) {
 
 	var profiler interface {
 		Stop()
-	} = nil
+	}
 
 	if c.GlobalBool("cpu-profile") {
 		log.Info("CPU profiler started.")
@@ -114,6 +118,7 @@ func serve(c *cli.Context) {
 	os.Exit(0)
 }
 
+// New returns a new instance of the Cmd struct.
 func New() *Cmd {
 	app := cli.NewApp()
 	app.Name = "honeytrap"

--- a/config/config.go
+++ b/config/config.go
@@ -22,10 +22,13 @@ var format = logging.MustStringFormatter(
 )
 
 type (
+
+	// HouseKeeper defines the settings for operation cleanup.
 	HouseKeeper struct {
 		Every Delay `toml:"every"`
 	}
 
+	// Delays sets the individual duration set for all ops.
 	// TODO: rename to Timers
 	Delays struct {
 		PushDelay        Delay `toml:"push_every"`
@@ -34,14 +37,17 @@ type (
 		HousekeeperDelay Delay `toml:"housekeeper_every"`
 	}
 
+	// Console defines the struct to contain the console logging level.
 	Console struct {
 		Level string `toml:"level"`
 	}
 
+	// Folders defines the data path for usage in container ops.
 	Folders struct {
 		Data string `toml:"data"`
 	}
 
+	// Config defines the central type where all configuration is umarhsalled to.
 	Config struct {
 		Token       string      `toml:"token"`
 		Template    string      `toml:"template"`
@@ -71,11 +77,13 @@ type (
 	}
 )
 
+// WebConfig defines the configuration for the web access point.
 type WebConfig struct {
 	Port string `toml:"port"`
 	Path string `toml:"path"`
 }
 
+// AgentConfig defines configuration for the agent server.
 type AgentConfig struct {
 	Port string `toml:"port"`
 	TLS  struct {
@@ -83,14 +91,17 @@ type AgentConfig struct {
 	} `toml:"tls"`
 }
 
+// HTTPProxyConfig defines the config type for the http proxy server.
 type HTTPProxyConfig struct {
 	Port string `toml:"port"`
 }
 
+// SIPProxyConfig defines the configuration struct for the sip server.
 type SIPProxyConfig struct {
 	Port string `toml:"port"`
 }
 
+// SMTPProxyConfig defines the configuration for the SMTPProxyConfig.
 type SMTPProxyConfig struct {
 	Port string `toml:"port"`
 	Host string `toml:"host"`
@@ -100,12 +111,15 @@ type SMTPProxyConfig struct {
 	} `toml:"tls"`
 }
 
+// Delay defines a duration type.
 type Delay time.Duration
 
+// Duration returns the type of the giving duration from the provided pointer.
 func (t *Delay) Duration() time.Duration {
 	return time.Duration(*t)
 }
 
+// UnmarshalText handles unmarshalling duration values from the provided slice.
 func (t *Delay) UnmarshalText(text []byte) error {
 	s := string(text)
 
@@ -119,6 +133,7 @@ func (t *Delay) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// DefaultConfig defines the default Config to be used to set default values.
 var DefaultConfig = Config{
 	Token:     "",
 	Template:  "honeytrap",
@@ -142,11 +157,13 @@ var DefaultConfig = Config{
 	},
 }
 
+// New returns a new instance of the config struct.
 func New() (*Config, error) {
 	c := DefaultConfig
 	return &c, nil
 }
 
+// Load attempts to load the giving toml configuration file.
 func (c *Config) Load(file string) error {
 	conf := Config{}
 	if _, err := toml.DecodeFile(file, &conf); err != nil {
@@ -161,7 +178,7 @@ func (c *Config) Load(file string) error {
 	for _, log := range conf.Logging {
 		var err error
 
-		var output io.Writer = os.Stdout
+		var output io.Writer
 
 		switch log.Output {
 		case "stdout":

--- a/config/utils.go
+++ b/config/utils.go
@@ -14,7 +14,7 @@ func ConvertToInt(target string, def int) int {
 	return fo
 }
 
-// should become internal functions , config should return time.Duration
+// MakeDuration should become internal functions , config should return time.Duration
 func MakeDuration(target string, def int) time.Duration {
 	if !elapso.MatchString(target) {
 		return time.Duration(def)

--- a/director/director_linux.go
+++ b/director/director_linux.go
@@ -24,7 +24,7 @@ type Director struct {
 }
 
 // New returns a new instance of a Director.
-func New(conf *config.Config, events *pushers.EventDelivery) *Director {
+func New(conf *config.Config, events pushers.Events) *Director {
 	// TODO: Need to replace this with Event API.
 	// pusher := pushers.NewRecordPusher(conf)
 

--- a/director/director_linux.go
+++ b/director/director_linux.go
@@ -10,6 +10,7 @@ import (
 
 	config "github.com/honeytrap/honeytrap/config"
 	providers "github.com/honeytrap/honeytrap/providers"
+	"github.com/honeytrap/honeytrap/pushers"
 
 	lxc "github.com/honeytrap/golxc"
 )
@@ -23,14 +24,14 @@ type Director struct {
 }
 
 // New returns a new instance of a Director.
-func New(conf *config.Config) *Director {
+func New(conf *config.Config, events *pushers.EventDelivery) *Director {
 	// TODO: Need to replace this with Event API.
 	// pusher := pushers.NewRecordPusher(conf)
 
 	d := &Director{
-		containers: map[string]providers.Container{},
 		config:     conf,
-		provider:   providers.NewLxcProvider(conf),
+		containers: map[string]providers.Container{},
+		provider:   providers.NewLxcProvider(conf, events),
 	}
 
 	d.registerContainers()

--- a/providers/container.go
+++ b/providers/container.go
@@ -2,6 +2,7 @@ package providers
 
 import "net"
 
+// Container defines a type which exposes methods for connecting to a container.
 type Container interface {
 	Dial(string) (net.Conn, error)
 	Name() string

--- a/providers/lxccontainer.go
+++ b/providers/lxccontainer.go
@@ -38,11 +38,11 @@ type LxcConfig struct {
 // lxc based containers.
 type LxcProvider struct {
 	config *config.Config
-	events *pushers.EventDelivery
+	events pushers.Events
 }
 
 // NewLxcProvider returns a new instance of a LxcProvider as a Provider.
-func NewLxcProvider(config *config.Config, events *pushers.EventDelivery) Provider {
+func NewLxcProvider(config *config.Config, events pushers.Events) Provider {
 	return &LxcProvider{config, events}
 }
 

--- a/providers/lxccontainer.go
+++ b/providers/lxccontainer.go
@@ -13,10 +13,15 @@ import (
 	"time"
 
 	"github.com/honeytrap/honeytrap/config"
+	"github.com/honeytrap/honeytrap/pushers"
+	"github.com/honeytrap/honeytrap/pushers/message"
 	"github.com/honeytrap/honeytrap/sniffer"
+	logging "github.com/op/go-logging"
 
 	lxc "github.com/honeytrap/golxc"
 )
+
+var log = logging.MustGetLogger("honeytrap:providers")
 
 /*
 TODO: enable providers registration
@@ -24,18 +29,24 @@ var (
 	_ = director.RegisterProvider("lxc", NewLxcContainer)
 )*/
 
+// LxcConfig defines a struct to provide configuration fields for a LxcProvider.
 type LxcConfig struct {
 	Template string
 }
 
+// LxcProvider defines a struct which loads the needed configuration for handling
+// lxc based containers.
 type LxcProvider struct {
 	config *config.Config
+	events *pushers.EventDelivery
 }
 
-func NewLxcProvider(config *config.Config) Provider {
-	return &LxcProvider{config}
+// NewLxcProvider returns a new instance of a LxcProvider as a Provider.
+func NewLxcProvider(config *config.Config, events *pushers.EventDelivery) Provider {
+	return &LxcProvider{config, events}
 }
 
+// LxcContainer defines a struct to encapsulated a lxc.Container.
 type LxcContainer struct {
 	ip       string
 	name     string
@@ -49,11 +60,12 @@ type LxcContainer struct {
 	provider *LxcProvider
 }
 
+// NewContainer returns a new LxcContainer from the provider.
 func (lp *LxcProvider) NewContainer(name string) (Container, error) {
 	c := LxcContainer{
-		config:   lp.config,
-		name:     name,
 		provider: lp,
+		name:     name,
+		config:   lp.config,
 		idle:     time.Now(),
 		sf:       sniffer.New(lp.config.NetFilter),
 	}
@@ -68,6 +80,7 @@ func (lp *LxcProvider) NewContainer(name string) (Container, error) {
 	return &c, nil
 }
 
+// clone attempts to clone the underline lxc.Container.
 func (c *LxcContainer) clone() error {
 	log.Debugf("Creating new container %s from template %s", c.name, c.config.Template)
 
@@ -78,6 +91,17 @@ func (c *LxcContainer) clone() error {
 	}
 
 	defer lxc.Release(c1)
+
+	c.provider.events.Deliver(message.Event{
+		Sensor:   c.name,
+		Category: "Containers",
+		Type:     message.ContainerClone,
+		Details: map[string]interface{}{
+			"name":     c.name,
+			"template": c.template,
+			"ip":       c.ip,
+		},
+	})
 
 	// http://developerblog.redhat.com/2014/09/30/overview-storage-scalability-docker/
 	// TODO: use overlayfs / make it configurable
@@ -104,6 +128,7 @@ func (c *LxcContainer) clone() error {
 	return nil
 }
 
+// start begins the call to the lxc.Container.
 func (c *LxcContainer) start() error {
 	log.Infof("Starting container")
 
@@ -112,9 +137,33 @@ func (c *LxcContainer) start() error {
 	if !c.c.Defined() {
 		if err := c.clone(); err != nil {
 			log.Error(err.Error())
+
+			c.provider.events.Deliver(message.Event{
+				Sensor:   c.name,
+				Category: "Containers",
+				Type:     message.ContainerStarted,
+				Details: map[string]interface{}{
+					"error":    err.Error(),
+					"name":     c.name,
+					"template": c.template,
+					"ip":       c.ip,
+				},
+			})
+
 			return err
 		}
 	}
+
+	c.provider.events.Deliver(message.Event{
+		Sensor:   c.name,
+		Category: "Containers",
+		Type:     message.ContainerStarted,
+		Details: map[string]interface{}{
+			"name":     c.name,
+			"template": c.template,
+			"ip":       c.ip,
+		},
+	})
 
 	// run independent of our process
 	c.c.WantDaemonize(true)
@@ -134,6 +183,8 @@ func (c *LxcContainer) start() error {
 	return nil
 }
 
+// housekeeper handls the needed process of handling internal logic
+// in maintaining the provided lxc.Container.
 func (c *LxcContainer) housekeeper() {
 	// container lifetime function
 	log.Infof("Housekeeper (%s) started.", c.name)
@@ -158,24 +209,51 @@ func (c *LxcContainer) housekeeper() {
 	}
 }
 
+// isRunning returns true/false if the container is in running state.
 func (c *LxcContainer) isRunning() bool {
 	return c.c.State() == lxc.RUNNING
 }
 
+// isStopped returns true/false if the container is in stopped state.
 func (c *LxcContainer) isStopped() bool {
 	return c.c.State() == lxc.STOPPED
 }
 
+// isFrozen returns true/false if the container is in frozen state.
 func (c *LxcContainer) isFrozen() bool {
 	return c.c.State() == lxc.FROZEN
 }
 
+// unfreeze sets the internal container into an unfrozen state.
 func (c *LxcContainer) unfreeze() error {
 	log.Infof("Unfreezing container: %s", c.name)
 
 	if err := c.c.Unfreeze(); err != nil {
+		c.provider.events.Deliver(message.Event{
+			Sensor:   c.name,
+			Category: "Containers",
+			Type:     message.ContainerFrozen,
+			Details: map[string]interface{}{
+				"error":    err.Error(),
+				"name":     c.name,
+				"template": c.template,
+				"ip":       c.ip,
+			},
+		})
+
 		return err
 	}
+
+	c.provider.events.Deliver(message.Event{
+		Sensor:   c.name,
+		Category: "Containers",
+		Type:     message.ContainerUnfrozen,
+		Details: map[string]interface{}{
+			"name":     c.name,
+			"template": c.template,
+			"ip":       c.ip,
+		},
+	})
 
 	if err := c.settle(); err != nil {
 		return err
@@ -188,14 +266,16 @@ func (c *LxcContainer) unfreeze() error {
 	return nil
 }
 
+// settle runs the process to take the container into a proper running state.
 func (c *LxcContainer) settle() error {
-	log.Infof("Waiting for container to settle %s\n", c.name)
+	log.Infof("Waiting for container to settle %s", c.name)
 
 	if !c.c.Wait(lxc.RUNNING, 30) {
-		return fmt.Errorf("LxcContainer still not running %s\n", c.name)
+		return fmt.Errorf("lxccontainer still not running %s", c.name)
 	}
 
-	var retries int = 0
+	retries := 0
+
 	for {
 		ip, err := c.c.IPAddress("eth0")
 		if err == nil {
@@ -205,13 +285,13 @@ func (c *LxcContainer) settle() error {
 		}
 
 		if retries < 50 {
-			log.Debugf("Waiting for ip to settle %s (%s)\n", c.name, err.Error())
+			log.Debugf("Waiting for ip to settle %s (%s)", c.name, err.Error())
 			time.Sleep(time.Millisecond * 200)
 			retries++
 			continue
 		}
 
-		return fmt.Errorf("Could not get an IP address.")
+		return fmt.Errorf("Could not get an IP address")
 	}
 
 	var isets []string
@@ -232,7 +312,7 @@ func (c *LxcContainer) settle() error {
 	}
 
 	if len(isets) == 0 {
-		return fmt.Errorf("Could not get an network device.")
+		return fmt.Errorf("could not get an network device")
 	}
 
 	c.idevice = isets[0]
@@ -242,6 +322,7 @@ func (c *LxcContainer) settle() error {
 	return nil
 }
 
+// ensureStated validates that the internal container has started.
 func (c *LxcContainer) ensureStarted() error {
 	if c.isFrozen() {
 		return c.unfreeze()
@@ -254,6 +335,7 @@ func (c *LxcContainer) ensureStarted() error {
 	return nil
 }
 
+// Device returns the network device connected to the container.
 func (c *LxcContainer) Device() (string, error) {
 	if c.idevice == "" {
 		return "", fmt.Errorf("Unable to get device")
@@ -261,25 +343,32 @@ func (c *LxcContainer) Device() (string, error) {
 	return c.idevice, nil
 }
 
+// Name returns the underling Name of the container.
 func (c *LxcContainer) Name() string {
 	return (c.name)
 }
 
+// lxcContainerConn defines a custom connection type which proxies the data
+// for the container.
 type lxcContainerConn struct {
 	net.Conn
 	container *LxcContainer
 }
 
+// Read reads the giving set of data from the container connection to the
+// byte slice.
 func (c lxcContainerConn) Read(b []byte) (n int, err error) {
 	c.container.stillActive()
 	return c.Conn.Read(b)
 }
 
+// Write writes the data into byte slice from the container.
 func (c lxcContainerConn) Write(b []byte) (n int, err error) {
 	c.container.stillActive()
 	return c.Conn.Write(b)
 }
 
+// stillActive returns an error if the containerr is not still active
 func (c *LxcContainer) stillActive() error {
 	if err := c.ensureStarted(); err != nil {
 		return err
@@ -292,6 +381,8 @@ func (c *LxcContainer) stillActive() error {
 	return nil
 }
 
+// deltaUp retrieves the underline delta changes for the containers
+// filesystem and writes it up to the underline host system.
 func (c *LxcContainer) deltaUp() (string, error) {
 	fo, err := ioutil.TempFile("", c.name)
 	if err != nil {
@@ -314,6 +405,8 @@ func (c *LxcContainer) deltaUp() (string, error) {
 	return fo.Name(), nil
 }
 
+// checkpoint retrieves the current state of the container and
+// compresses it through the checkpoint API exposed by the lxc.Container.
 func (c *LxcContainer) checkpoint() (string, error) {
 	tmpdir, err := ioutil.TempDir("", c.name)
 	if err != nil {
@@ -352,11 +445,23 @@ func (c *LxcContainer) checkpoint() (string, error) {
 	return fo.Name(), nil
 }
 
+// freeze sets the container into a freeze state.
 func (c *LxcContainer) freeze() error {
 	if !c.isRunning() {
 		// not running
 		return nil
 	}
+
+	c.provider.events.Deliver(message.Event{
+		Sensor:   c.name,
+		Category: "Containers",
+		Type:     message.ContainerFrozen,
+		Details: map[string]interface{}{
+			"name":     c.name,
+			"template": c.template,
+			"ip":       c.ip,
+		},
+	})
 
 	// should actually first checkpoint, stop sniffer and freeze, then tar
 	for {
@@ -374,8 +479,8 @@ func (c *LxcContainer) freeze() error {
 		}
 
 		defer func() {
-			if err := os.Remove(chp.Name()); err != nil {
-				log.Errorf("Error deleting file (%s): %s", chp.Name(), err.Error())
+			if cerr := os.Remove(chp.Name()); err != nil {
+				log.Errorf("Error deleting file (%s): %s", chp.Name(), cerr.Error())
 			}
 		}()
 
@@ -387,10 +492,18 @@ func (c *LxcContainer) freeze() error {
 
 		endpoint := fmt.Sprintf("http://api.honeytrap.io/v1/container/%s/checkpoint", c.name)
 
-		// TODO: Replace with Event API.
-		// c.provider.pusher.Push(endpoint, buff)
-		_ = endpoint
-		_ = buff
+		c.provider.events.Deliver(message.Event{
+			Data:     buff,
+			Sensor:   c.name,
+			Category: "Containers",
+			Type:     message.ContainerDataCheckpoint,
+			Details: map[string]interface{}{
+				"endpoint": endpoint,
+				"name":     c.name,
+				"template": c.template,
+				"ip":       c.ip,
+			},
+		})
 		break
 	}
 
@@ -416,11 +529,19 @@ func (c *LxcContainer) freeze() error {
 		}
 
 		log.Debugf("Pushing packets")
-		// TODO: Replace with Event API.
-		// c.provider.pusher.Push(endpoint, buff)
-		_ = endpoint
-		_ = buff
 
+		c.provider.events.Deliver(message.Event{
+			Data:     buff,
+			Sensor:   c.name,
+			Category: "Containers",
+			Type:     message.ContainerDataPacket,
+			Details: map[string]interface{}{
+				"endpoint": endpoint,
+				"name":     c.name,
+				"template": c.template,
+				"ip":       c.ip,
+			},
+		})
 		break
 	}
 
@@ -439,8 +560,8 @@ func (c *LxcContainer) freeze() error {
 		}
 
 		defer func() {
-			if err := os.Remove(r.Name()); err != nil {
-				log.Errorf("Error deleting file (%s): %s", r.Name(), err.Error())
+			if cerr := os.Remove(r.Name()); cerr != nil {
+				log.Errorf("Error deleting file (%s): %s", r.Name(), cerr.Error())
 			}
 		}()
 
@@ -452,16 +573,25 @@ func (c *LxcContainer) freeze() error {
 
 		endpoint := fmt.Sprintf("http://api.honeytrap.io/v1/container/%s/data", c.name)
 
-		// TODO: Replace with Event API.
-		// c.provider.pusher.Push(endpoint, buff)
-		_ = endpoint
-		_ = buff
+		c.provider.events.Deliver(message.Event{
+			Data:     buff,
+			Sensor:   c.name,
+			Category: "Containers",
+			Type:     message.ContainerTarBackup,
+			Details: map[string]interface{}{
+				"endpoint": endpoint,
+				"name":     c.name,
+				"template": c.template,
+				"ip":       c.ip,
+			},
+		})
 		break
 	}
 
 	return nil
 }
 
+// stop stops the container and shuts it down.
 func (c *LxcContainer) stop() error {
 	if c.isStopped() {
 		// already stopped
@@ -471,16 +601,42 @@ func (c *LxcContainer) stop() error {
 	log.Infof("LxcContainer (%s) stopping (ip: %s)", c.name, c.ip)
 
 	if err := c.c.Stop(); err != nil {
+		c.provider.events.Deliver(message.Event{
+			Sensor:   c.name,
+			Category: "Containers",
+			Type:     message.ContainerStopped,
+			Details: map[string]interface{}{
+				"error":    err.Error(),
+				"name":     c.name,
+				"template": c.template,
+				"ip":       c.ip,
+			},
+		})
 		return err
 	}
+
+	c.provider.events.Deliver(message.Event{
+		Sensor:   c.name,
+		Category: "Containers",
+		Type:     message.ContainerStopped,
+		Details: map[string]interface{}{
+			"name":     c.name,
+			"template": c.template,
+			"ip":       c.ip,
+		},
+	})
 
 	return nil
 }
 
+// CleanUp attempts to run certain process to cleanup
+// the state of the uinternal container.
 func (c *LxcContainer) CleanUp() error {
 	return nil
 }
 
+// Dial attempts to connect to the internal network of the
+// internal container.
 func (c *LxcContainer) Dial(port string) (net.Conn, error) {
 	if err := c.ensureStarted(); err != nil {
 		return nil, err
@@ -510,7 +666,7 @@ func (c *LxcContainer) Dial(port string) (net.Conn, error) {
 			continue
 		}
 
-		return nil, fmt.Errorf("Could not connect to container.")
+		return nil, fmt.Errorf("could not connect to container")
 	}
 
 	return lxcContainerConn{Conn: conn, container: c}, err

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -1,5 +1,6 @@
 package providers
 
+// Provider defines a function which returns a NewContainer.
 type Provider interface {
 	NewContainer(string) (Container, error)
 }

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -1,9 +1,5 @@
 package providers
 
-import "github.com/op/go-logging"
-
-var log = logging.MustGetLogger("honeytrap:providers")
-
 type Provider interface {
 	NewContainer(string) (Container, error)
 }

--- a/providers/utils.go
+++ b/providers/utils.go
@@ -9,14 +9,17 @@ import (
 	"path/filepath"
 )
 
+// FileCloser defines a struct which implements the io.Closer for a file object
+// which removes the path when closed.
 type FileCloser struct {
 	*os.File
 	path string
 }
 
+// Close calls the file.Close method and removes the file.
 func (f *FileCloser) Close() error {
 	ec := f.File.Close()
-	log.Info("Will Remove %s", f.path)
+	log.Infof("Will Remove %s", f.path)
 	ex := os.Remove(f.path)
 
 	if ex == nil {
@@ -26,6 +29,7 @@ func (f *FileCloser) Close() error {
 	return ex
 }
 
+// NewFileCloser returns a new instance of the FileCloser.
 func NewFileCloser(path string) (*FileCloser, error) {
 	ff, err := os.Open(path)
 
@@ -36,12 +40,12 @@ func NewFileCloser(path string) (*FileCloser, error) {
 	return &FileCloser{ff, path}, nil
 }
 
-//BufferCloser closes a byte.Buffer
+// BufferCloser closes a byte.Buffer
 type BufferCloser struct {
 	*bytes.Buffer
 }
 
-//NewBufferCloser returns a new closer for a bytes.Buffer
+// NewBufferCloser returns a new closer for a bytes.Buffer
 func NewBufferCloser(bu *bytes.Buffer) *BufferCloser {
 	return &BufferCloser{bu}
 }
@@ -52,7 +56,7 @@ func (b *BufferCloser) Close() error {
 	return nil
 }
 
-//GzipWalker walks a path and turns it into a tar written into a bytes.Buffer
+// GzipWalker walks a path and turns it into a tar written into a bytes.Buffer
 func GzipWalker(file string, tmp io.Writer) error {
 	f, err := os.Open(file)
 
@@ -72,7 +76,7 @@ func GzipWalker(file string, tmp io.Writer) error {
 	return err
 }
 
-//TarWalker walks a path and turns it into a tar written into a bytes.Buffer
+// TarWalker walks a path and turns it into a tar written into a bytes.Buffer
 func TarWalker(rootpath string, w io.Writer) error {
 	tz := tar.NewWriter(w)
 	defer tz.Close()

--- a/proxies/conn.go
+++ b/proxies/conn.go
@@ -5,7 +5,6 @@ import (
 
 	providers "github.com/honeytrap/honeytrap/providers"
 	pushers "github.com/honeytrap/honeytrap/pushers"
-	"github.com/honeytrap/honeytrap/pushers/message"
 )
 
 // ProxyConn defines a base decorator over a net.Conn for proxy purposes.
@@ -31,29 +30,13 @@ func (cw *ProxyConn) RemoteHost() string {
 func (cw *ProxyConn) Close() error {
 	if cw.Server != nil {
 
-		cw.Event.Deliver(message.Event{
-			Sensor:   "ProxyConn.Server",
-			Category: "Connections",
-			Type:     message.ConnectionClosed,
-			Details: map[string]interface{}{
-				"remoteAddr": cw.Server.RemoteAddr().String(),
-				"localAddr":  cw.Server.LocalAddr().String(),
-			},
-		})
-
+		ev := EventConnectionClosed(cw.RemoteAddr(), "ProxyConn.Conn", nil)
+		cw.Event.Deliver(ev)
 		cw.Server.Close()
 	}
-	if cw.Conn != nil {
-		cw.Event.Deliver(message.Event{
-			Sensor:   "ProxyConn.Conn",
-			Category: "Connections",
-			Type:     message.ConnectionClosed,
-			Details: map[string]interface{}{
-				"remoteAddr": cw.Server.RemoteAddr().String(),
-				"localAddr":  cw.Server.LocalAddr().String(),
-			},
-		})
 
+	if cw.Conn != nil {
+		cw.Event.Deliver(EventConnectionClosed(cw.RemoteAddr(), "ProxyConn.Conn", nil))
 		return cw.Conn.Close()
 	}
 

--- a/proxies/conn.go
+++ b/proxies/conn.go
@@ -5,8 +5,10 @@ import (
 
 	providers "github.com/honeytrap/honeytrap/providers"
 	pushers "github.com/honeytrap/honeytrap/pushers"
+	"github.com/honeytrap/honeytrap/pushers/message"
 )
 
+// ProxyConn defines a base decorator over a net.Conn for proxy purposes.
 type ProxyConn struct {
 	// Connection with host
 	net.Conn
@@ -16,18 +18,42 @@ type ProxyConn struct {
 	Container providers.Container
 
 	Pusher *pushers.Pusher
+	Event  *pushers.EventDelivery
 }
 
+// RemoteHost returns the addr ip of the giving connection.
 func (cw *ProxyConn) RemoteHost() string {
 	host, _, _ := net.SplitHostPort(cw.RemoteAddr().String())
 	return host
 }
 
+// Close closes the ProxyConn internal net.Conn.
 func (cw *ProxyConn) Close() error {
 	if cw.Server != nil {
+
+		cw.Event.Deliver(message.Event{
+			Sensor:   "ProxyConn.Server",
+			Category: "Connections",
+			Type:     message.ConnectionClosed,
+			Details: map[string]interface{}{
+				"remoteAddr": cw.Server.RemoteAddr().String(),
+				"localAddr":  cw.Server.LocalAddr().String(),
+			},
+		})
+
 		cw.Server.Close()
 	}
 	if cw.Conn != nil {
+		cw.Event.Deliver(message.Event{
+			Sensor:   "ProxyConn.Conn",
+			Category: "Connections",
+			Type:     message.ConnectionClosed,
+			Details: map[string]interface{}{
+				"remoteAddr": cw.Server.RemoteAddr().String(),
+				"localAddr":  cw.Server.LocalAddr().String(),
+			},
+		})
+
 		return cw.Conn.Close()
 	}
 

--- a/proxies/conn.go
+++ b/proxies/conn.go
@@ -17,7 +17,7 @@ type ProxyConn struct {
 	Container providers.Container
 
 	Pusher *pushers.Pusher
-	Event  *pushers.EventDelivery
+	Event  pushers.Events
 }
 
 // RemoteHost returns the addr ip of the giving connection.
@@ -30,13 +30,12 @@ func (cw *ProxyConn) RemoteHost() string {
 func (cw *ProxyConn) Close() error {
 	if cw.Server != nil {
 
-		ev := EventConnectionClosed(cw.RemoteAddr(), "ProxyConn.Conn", nil)
-		cw.Event.Deliver(ev)
+		cw.Event.Deliver(EventConnectionClosed(cw.RemoteAddr(), cw.LocalAddr(), "ProxyConn.Conn", nil, nil))
 		cw.Server.Close()
 	}
 
 	if cw.Conn != nil {
-		cw.Event.Deliver(EventConnectionClosed(cw.RemoteAddr(), "ProxyConn.Conn", nil))
+		cw.Event.Deliver(EventConnectionClosed(cw.RemoteAddr(), cw.LocalAddr(), "ProxyConn.Conn", nil, nil))
 		return cw.Conn.Close()
 	}
 

--- a/proxies/events.go
+++ b/proxies/events.go
@@ -8,44 +8,47 @@ import (
 
 // ConnectionEvent defines a function to return an event object for related
 // connection events.
-func ConnectionEvent(ip net.Addr, ev message.EventType, sensor string, data interface{}) message.Event {
+func ConnectionEvent(host, local net.Addr, ev message.EventType, sensor string, data interface{}, dt map[string]interface{}) message.Event {
 	return message.Event{
-		Sensor:   sensor,
-		Category: "Connections",
-		Type:     ev,
-		Data:     data,
-		Details: map[string]interface{}{
-			"addr": ip.String(),
-		},
+		Sensor:    sensor,
+		Category:  "Connections",
+		Type:      ev,
+		Data:      data,
+		HostAddr:  host.String(),
+		LocalAddr: local.String(),
+		Details:   dt,
 	}
 }
 
-// EventConnectionPing defines a function which returns a event object for a
-// ping request with a connection.
-func EventConnectionPing(ip net.Addr, sensor string, data error) message.Event {
-	return ConnectionEvent(ip, message.Ping, sensor, data)
+// AgentRequestEvent defines a function which returns a event object for a
+// request connection.
+func AgentRequestEvent(host, local net.Addr, sensor string, session string, data interface{}, detail map[string]interface{}) message.Event {
+	return message.Event{
+		Data:      data,
+		SessionID: session,
+		Sensor:    sensor,
+		Category:  "agent-request",
+		Type:      message.Ping,
+		HostAddr:  host.String(),
+		LocalAddr: local.String(),
+		Details:   detail,
+	}
 }
 
 // EventConnectionError defines a function which returns a event object for a
 // error occurence with a connection.
-func EventConnectionError(ip net.Addr, sensor string, data error) message.Event {
-	return ConnectionEvent(ip, message.ConnectionError, sensor, data)
-}
-
-// EventConnectionRequest defines a function which returns a event object for a
-// request connection.
-func EventConnectionRequest(ip net.Addr, sensor string, data interface{}) message.Event {
-	return ConnectionEvent(ip, message.ConnectionRequest, sensor, data)
+func EventConnectionError(ip, local net.Addr, sensor string, data error, dt map[string]interface{}) message.Event {
+	return ConnectionEvent(ip, local, message.ConnectionError, sensor, data, dt)
 }
 
 // EventConnectionClosed defines a function which returns a event object for a
 // closed connection.
-func EventConnectionClosed(ip net.Addr, sensor string, data interface{}) message.Event {
-	return ConnectionEvent(ip, message.ConnectionClosed, sensor, data)
+func EventConnectionClosed(ip, local net.Addr, sensor string, data interface{}, detail map[string]interface{}) message.Event {
+	return ConnectionEvent(ip, local, message.ConnectionClosed, sensor, data, detail)
 }
 
 // EventConnectionOpened defines a function which returns a event object for a
 // closed connection.
-func EventConnectionOpened(ip net.Addr, sensor string, data interface{}) message.Event {
-	return ConnectionEvent(ip, message.ConnectionStarted, sensor, data)
+func EventConnectionOpened(ip, local net.Addr, sensor string, data interface{}, detail map[string]interface{}) message.Event {
+	return ConnectionEvent(ip, local, message.ConnectionStarted, sensor, data, detail)
 }

--- a/proxies/events.go
+++ b/proxies/events.go
@@ -1,0 +1,51 @@
+package proxies
+
+import (
+	"net"
+
+	"github.com/honeytrap/honeytrap/pushers/message"
+)
+
+// ConnectionEvent defines a function to return an event object for related
+// connection events.
+func ConnectionEvent(ip net.Addr, ev message.EventType, sensor string, data interface{}) message.Event {
+	return message.Event{
+		Sensor:   sensor,
+		Category: "Connections",
+		Type:     ev,
+		Data:     data,
+		Details: map[string]interface{}{
+			"addr": ip.String(),
+		},
+	}
+}
+
+// EventConnectionPing defines a function which returns a event object for a
+// ping request with a connection.
+func EventConnectionPing(ip net.Addr, sensor string, data error) message.Event {
+	return ConnectionEvent(ip, message.Ping, sensor, data)
+}
+
+// EventConnectionError defines a function which returns a event object for a
+// error occurence with a connection.
+func EventConnectionError(ip net.Addr, sensor string, data error) message.Event {
+	return ConnectionEvent(ip, message.ConnectionError, sensor, data)
+}
+
+// EventConnectionRequest defines a function which returns a event object for a
+// request connection.
+func EventConnectionRequest(ip net.Addr, sensor string, data interface{}) message.Event {
+	return ConnectionEvent(ip, message.ConnectionRequest, sensor, data)
+}
+
+// EventConnectionClosed defines a function which returns a event object for a
+// closed connection.
+func EventConnectionClosed(ip net.Addr, sensor string, data interface{}) message.Event {
+	return ConnectionEvent(ip, message.ConnectionClosed, sensor, data)
+}
+
+// EventConnectionOpened defines a function which returns a event object for a
+// closed connection.
+func EventConnectionOpened(ip net.Addr, sensor string, data interface{}) message.Event {
+	return ConnectionEvent(ip, message.ConnectionStarted, sensor, data)
+}

--- a/proxies/http/http.go
+++ b/proxies/http/http.go
@@ -22,7 +22,7 @@ var log = logging.MustGetLogger("honeytrap:proxy:sip")
 // ListenHTTP returns a new listener to handle proxy connections through the
 // http protocol.
 // TODO: Change amount of params.
-func ListenHTTP(address string, d *director.Director, p *pushers.Pusher, e *pushers.EventDelivery, c *config.Config) (net.Listener, error) {
+func ListenHTTP(address string, d *director.Director, p *pushers.Pusher, e pushers.Events, c *config.Config) (net.Listener, error) {
 	l, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatal(err)

--- a/proxies/http/http.go
+++ b/proxies/http/http.go
@@ -19,22 +19,28 @@ import (
 
 var log = logging.MustGetLogger("honeytrap:proxy:sip")
 
+// ListenHTTP returns a new listener to handle proxy connections through the
+// http protocol.
 // TODO: Change amount of params.
-func ListenHTTP(address string, d *director.Director, p *pushers.Pusher, c *config.Config) (net.Listener, error) {
+func ListenHTTP(address string, d *director.Director, p *pushers.Pusher, e *pushers.EventDelivery, c *config.Config) (net.Listener, error) {
 	l, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	return &HTTPProxyListener{
-		proxies.NewProxyListener(l, d, p),
+		proxies.NewProxyListener(l, d, p, e),
 	}, nil
 }
 
+// HTTPProxyListener defines the struct which handles the underline operation for
+// proxying between two http request.
 type HTTPProxyListener struct {
 	*proxies.ProxyListener
 }
 
+// Accept returns a new http connection which handles the proxying operations
+// for that request.
 func (l *HTTPProxyListener) Accept() (net.Conn, error) {
 	conn, err := l.ProxyListener.Accept()
 	if err != nil {
@@ -45,10 +51,12 @@ func (l *HTTPProxyListener) Accept() (net.Conn, error) {
 	return &HTTPProxyConn{conn.(*proxies.ProxyConn)}, err
 }
 
+// HTTPProxyConn defines a connection struct for the http connection.
 type HTTPProxyConn struct {
 	*proxies.ProxyConn
 }
 
+// HTTPRequest defines a data struct for the recieved http request.
 type HTTPRequest struct {
 	Date          time.Time           `json:"timestamp"`
 	Host          string              `json:"host"`
@@ -62,6 +70,7 @@ type HTTPRequest struct {
 	Headers       map[string][]string `json:"headers"`
 }
 
+// Proxy initializes and proxies the underline connection operation.
 func (p *HTTPProxyConn) Proxy() error {
 	sessionID := uuid.NewV4()
 

--- a/proxies/listen.go
+++ b/proxies/listen.go
@@ -12,11 +12,11 @@ type ProxyListener struct {
 	net.Listener
 	director *director.Director
 	pusher   *pushers.Pusher
-	events   *pushers.EventDelivery
+	events   pushers.Events
 }
 
 // NewProxyListener returns a new instance for a ProxyListener.
-func NewProxyListener(l net.Listener, d *director.Director, p *pushers.Pusher, e *pushers.EventDelivery) *ProxyListener {
+func NewProxyListener(l net.Listener, d *director.Director, p *pushers.Pusher, e pushers.Events) *ProxyListener {
 	return &ProxyListener{
 		l,
 		d,
@@ -30,24 +30,33 @@ func (lw *ProxyListener) Accept() (c net.Conn, err error) {
 	c, err = lw.Listener.Accept()
 	if err != nil {
 
-		lw.events.Deliver(EventConnectionError(lw.Listener.Addr(), "ProxyConn", err))
+		lw.events.Deliver(EventConnectionError(c.RemoteAddr(), c.LocalAddr(), "ProxyConn", nil, map[string]interface{}{
+			"error": err,
+		}))
 
 		return nil, err
 	}
 
-	lw.events.Deliver(EventConnectionOpened(c.LocalAddr(), "ProxyConn", nil))
+	lw.events.Deliver(EventConnectionOpened(c.RemoteAddr(), c.LocalAddr(), "ProxyConn", nil, nil))
 
 	container, err := lw.director.GetContainer(c)
 	if err != nil {
-		lw.events.Deliver(EventConnectionError(c.LocalAddr(), "ProxyConn", err))
-		lw.events.Deliver(EventConnectionClosed(c.LocalAddr(), "ProxyConn", err))
+		lw.events.Deliver(EventConnectionError(c.RemoteAddr(), c.LocalAddr(), "ProxyConn", nil, map[string]interface{}{
+			"error": err,
+		}))
+
+		lw.events.Deliver(EventConnectionClosed(c.RemoteAddr(), c.LocalAddr(), "ProxyConn", nil, nil))
 		c.Close()
 		return nil, err
 	}
 
 	_, port, err := net.SplitHostPort(c.LocalAddr().String())
 	if err != nil {
-		lw.events.Deliver(EventConnectionClosed(c.LocalAddr(), "ProxyConn", err))
+		lw.events.Deliver(EventConnectionError(c.RemoteAddr(), c.LocalAddr(), "ProxyConn", nil, map[string]interface{}{
+			"error": err,
+		}))
+
+		lw.events.Deliver(EventConnectionClosed(c.RemoteAddr(), c.LocalAddr(), "ProxyConn", nil, nil))
 		c.Close()
 		return nil, err
 	}
@@ -57,7 +66,10 @@ func (lw *ProxyListener) Accept() (c net.Conn, err error) {
 	var c2 net.Conn
 	c2, err = container.Dial(port)
 	if err != nil {
-		lw.events.Deliver(EventConnectionClosed(c.LocalAddr(), "ProxyConn", err))
+		lw.events.Deliver(EventConnectionError(c.RemoteAddr(), c.LocalAddr(), "ProxyConn", nil, map[string]interface{}{
+			"error": err,
+		}))
+
 		c.Close()
 		return nil, err
 	}
@@ -69,7 +81,7 @@ func (lw *ProxyListener) Accept() (c net.Conn, err error) {
 func (lw *ProxyListener) Close() error {
 	log.Info("Listener closed")
 
-	lw.events.Deliver(EventConnectionClosed(lw.Addr(), "ProxyListener", nil))
+	lw.events.Deliver(EventConnectionError(lw.Addr(), lw.Addr(), "ProxyListener", nil, nil))
 
 	return lw.Listener.Close()
 }

--- a/proxies/listen.go
+++ b/proxies/listen.go
@@ -1,39 +1,80 @@
 package proxies
 
 import (
+	"net"
+
 	"github.com/honeytrap/honeytrap/director"
 	"github.com/honeytrap/honeytrap/pushers"
-	"net"
+	"github.com/honeytrap/honeytrap/pushers/message"
 )
 
+// ProxyListener defines a struct which holds a giving net.Listener.
 type ProxyListener struct {
 	net.Listener
 	director *director.Director
 	pusher   *pushers.Pusher
+	events   *pushers.EventDelivery
 }
 
-func NewProxyListener(l net.Listener, d *director.Director, p *pushers.Pusher) *ProxyListener {
+// NewProxyListener returns a new instance for a ProxyListener.
+func NewProxyListener(l net.Listener, d *director.Director, p *pushers.Pusher, e *pushers.EventDelivery) *ProxyListener {
 	return &ProxyListener{
 		l,
 		d,
 		p,
+		e,
 	}
 }
 
+// Accept returns a new net.Conn from the underline Proxy Listener.
 func (lw *ProxyListener) Accept() (c net.Conn, err error) {
 	c, err = lw.Listener.Accept()
 	if err != nil {
+		lw.events.Deliver(message.Event{
+			Sensor:   "ProxyConn",
+			Category: "Connections",
+			Type:     message.ConnectionError,
+			Details: map[string]interface{}{
+				"error": err.Error(),
+				"addr":  lw.Listener.Addr().String(),
+			},
+		})
 		return nil, err
 	}
 
+	lw.events.Deliver(message.Event{
+		Sensor:   "ProxyConn",
+		Category: "Connections",
+		Type:     message.ConnectionStarted,
+		Details: map[string]interface{}{
+			"Addr": c.LocalAddr().String(),
+		},
+	})
+
 	container, err := lw.director.GetContainer(c)
 	if err != nil {
+		lw.events.Deliver(message.Event{
+			Sensor:   "ProxyConn",
+			Category: "Connections",
+			Type:     message.ConnectionClosed,
+			Details: map[string]interface{}{
+				"Addr": c.LocalAddr().String(),
+			},
+		})
 		c.Close()
 		return nil, err
 	}
 
 	_, port, err := net.SplitHostPort(c.LocalAddr().String())
 	if err != nil {
+		lw.events.Deliver(message.Event{
+			Sensor:   "ProxyConn",
+			Category: "Connections",
+			Type:     message.ConnectionClosed,
+			Details: map[string]interface{}{
+				"Addr": c.LocalAddr().String(),
+			},
+		})
 		c.Close()
 		return nil, err
 	}
@@ -43,18 +84,40 @@ func (lw *ProxyListener) Accept() (c net.Conn, err error) {
 	var c2 net.Conn
 	c2, err = container.Dial(port)
 	if err != nil {
+		lw.events.Deliver(message.Event{
+			Sensor:   "ProxyConn",
+			Category: "Connections",
+			Type:     message.ConnectionClosed,
+			Details: map[string]interface{}{
+				"port":  port,
+				"error": err.Error(),
+				"Addr":  c.LocalAddr().String(),
+			},
+		})
 		c.Close()
 		return nil, err
 	}
 
-	return &ProxyConn{c, c2, container, lw.pusher}, err
+	return &ProxyConn{c, c2, container, lw.pusher, lw.events}, err
 }
 
+// Close closes the underline net.Listener.
 func (lw *ProxyListener) Close() error {
 	log.Info("Listener closed")
+
+	lw.events.Deliver(message.Event{
+		Sensor:   "ProxyListener",
+		Category: "Connections",
+		Type:     message.ConnectionClosed,
+		Details: map[string]interface{}{
+			"Addr": lw.Addr().String(),
+		},
+	})
+
 	return lw.Listener.Close()
 }
 
+// Addr returns the underline address of the internal net.Listener.
 func (lw *ProxyListener) Addr() net.Addr {
 	return lw.Listener.Addr()
 }

--- a/proxies/proxy.go
+++ b/proxies/proxy.go
@@ -14,26 +14,33 @@ import (
 
 var log = logging.MustGetLogger("honeytrap:proxy")
 
-type ProxyFn func(address string, d *director.Director, p *pushers.Pusher, c toml.Primitive) (net.Listener, error)
+// ProxyFn defines a function which delivers the needed listener for using the
+// underline proxy connection.
+type ProxyFn func(address string, d *director.Director, p *pushers.Pusher, el *pushers.EventDelivery, c toml.Primitive) (net.Listener, error)
 
 var proxies = map[string]ProxyFn{}
 
+// Register hands the giving ProxyFn into the map with the giving name as key.
 func Register(name string, fn ProxyFn) ProxyFn {
 	proxies[name] = fn
 	return fn
 }
 
+// Get returns the service function if it exists with the service name.
 func Get(service string) (ProxyFn, bool) {
 	fn, ok := proxies[service]
 	return fn, ok
 }
 
+// ProxyConfig defines the configuration object delivered to a proxy creator.
 type ProxyConfig struct {
 	pusher *pushers.Pusher
 
 	Config *config.Config
 }
 
+// Proxyer defines a interface which exposes a method to begin the internal
+// proxy operation of it's implementer.
 type Proxyer interface {
 	Proxy() error
 }

--- a/proxies/proxy.go
+++ b/proxies/proxy.go
@@ -16,7 +16,7 @@ var log = logging.MustGetLogger("honeytrap:proxy")
 
 // ProxyFn defines a function which delivers the needed listener for using the
 // underline proxy connection.
-type ProxyFn func(address string, d *director.Director, p *pushers.Pusher, el *pushers.EventDelivery, c toml.Primitive) (net.Listener, error)
+type ProxyFn func(address string, d *director.Director, p *pushers.Pusher, el pushers.Events, c toml.Primitive) (net.Listener, error)
 
 var proxies = map[string]ProxyFn{}
 

--- a/proxies/sip/sip.go
+++ b/proxies/sip/sip.go
@@ -18,7 +18,7 @@ var log = logging.MustGetLogger("honeytrap:proxy:sip")
 
 // ListenSIP returns a new net.Listener for listening for sip connections.
 // TODO: Change amount of params.
-func ListenSIP(address string, d *director.Director, p *pushers.Pusher, e *pushers.EventDelivery, c *config.Config) (net.Listener, error) {
+func ListenSIP(address string, d *director.Director, p *pushers.Pusher, e pushers.Events, c *config.Config) (net.Listener, error) {
 	l, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatal(err)

--- a/proxies/smtp/smtp.go
+++ b/proxies/smtp/smtp.go
@@ -27,7 +27,7 @@ import (
 // ListenSMTP returns a new proxy handler for the smtp provider.
 // TODO: Change amount of params.
 // combine listensmtp, smtpforwarder
-func ListenSMTP(address string, d *director.Director, p *pushers.Pusher, e *pushers.EventDelivery, c *config.Config) (net.Listener, error) {
+func ListenSMTP(address string, d *director.Director, p *pushers.Pusher, e pushers.Events, c *config.Config) (net.Listener, error) {
 	l, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatal(err)

--- a/proxies/smtp/smtp.go
+++ b/proxies/smtp/smtp.go
@@ -23,9 +23,10 @@ import (
 	pushers "github.com/honeytrap/honeytrap/pushers"
 )
 
+// ListenSMTP returns a new proxy handler for the smtp provider.
 // TODO: Change amount of params.
 // combine listensmtp, smtpforwarder
-func ListenSMTP(address string, d *director.Director, p *pushers.Pusher, c *config.Config) (net.Listener, error) {
+func ListenSMTP(address string, d *director.Director, p *pushers.Pusher, e *pushers.EventDelivery, c *config.Config) (net.Listener, error) {
 	l, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatal(err)
@@ -50,16 +51,19 @@ func ListenSMTP(address string, d *director.Director, p *pushers.Pusher, c *conf
 			l,
 			d,
 			p,
+			e,
 		},
 		&tlsconfig,
 	}, nil
 }
 
+// SMTPProxyListener defines a listener for smtp connections.
 type SMTPProxyListener struct {
 	*ProxyListener
 	tlsconfig *tls.Config
 }
 
+// NewSMTPForwarder returns a new instance of the SMTPForwarder.
 func NewSMTPForwarder(c *config.Config) (Forwarder, error) {
 	cert, err := tls.LoadX509KeyPair(
 		c.Proxies.SMTP.TLS.Certificate,
@@ -80,10 +84,12 @@ func NewSMTPForwarder(c *config.Config) (Forwarder, error) {
 	}, nil
 }
 
+// SMTPForwarder defines a forwader for smtp connection.
 type SMTPForwarder struct {
 	tlsconfig *tls.Config
 }
 
+// Forwarder defines a function to fowarded to the provided ProxyConn.
 func (sf *SMTPForwarder) Forward(pc *ProxyConn) Proxyer {
 	return &SMTPProxyConn{
 		ProxyConn: pc,
@@ -93,10 +99,13 @@ func (sf *SMTPForwarder) Forward(pc *ProxyConn) Proxyer {
 	}
 }
 
+// Fowarder defines a struct which contains the underline forwarding logic for
+// a proxy connection.
 type Forwarder interface {
 	Forward(pc *ProxyConn) Proxyer
 }
 
+// Accept handles the accept calls for provided SMTPProxyListener.
 func (l *SMTPProxyListener) Accept() (net.Conn, error) {
 	// _ = smconf := l.config.Proxies.SMTP
 
@@ -171,6 +180,7 @@ func newMessage() *Message {
 	return &Message{To: []*mail.Address{}}
 }
 
+// Read reads the giving data from the provided Reader.
 func (m *Message) Read(r io.Reader) error {
 	msg, err := mail.ReadMessage(r)
 	if err != nil {
@@ -449,6 +459,7 @@ func (s *SMTPProxyConn) proxy(text1, text2 *textproto.Conn) (string, error) {
 	return string(line), text1.W.Flush()
 }
 
+// Proxy initializes and proxy the internal connection details for each connection.
 func (s *SMTPProxyConn) Proxy( /*c *ProxyConfig*/ ) error {
 	defer func() {
 		// defer so we can add meta data to the message

--- a/proxies/smtp/smtp.go
+++ b/proxies/smtp/smtp.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/satori/go.uuid"
+	"github.com/upspin/upspin/log"
 
 	config "github.com/honeytrap/honeytrap/config"
 	director "github.com/honeytrap/honeytrap/director"

--- a/proxies/ssh/ssh.go
+++ b/proxies/ssh/ssh.go
@@ -120,7 +120,7 @@ func (t *PrivateKey) UnmarshalText(data []byte) (err error) {
 // that we can swap. So we can use for emxapl cowrie as well, but also our raw stack
 //
 // TODO: Change amount of params.
-func Listen(address string, d *director.Director, p *pushers.Pusher, events *pushers.EventDelivery, primitive toml.Primitive) (net.Listener, error) {
+func Listen(address string, d *director.Director, p *pushers.Pusher, events pushers.Events, primitive toml.Primitive) (net.Listener, error) {
 	c := Config{
 		Key:    nil,
 		Port:   ":8022",

--- a/proxies/ssh/ssh.go
+++ b/proxies/ssh/ssh.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/op/go-logging"
+	logging "github.com/op/go-logging"
 	"github.com/satori/go.uuid"
 
 	"github.com/honeytrap/honeytrap/director"
@@ -23,19 +23,22 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/BurntSushi/toml"
 	"io/ioutil"
+
+	"github.com/BurntSushi/toml"
 )
 
 var _ = proxies.Register("ssh", Listen)
 
 var log = logging.MustGetLogger("honeytrap:proxy:ssh")
 
+// contains different message header strings for ssh sensors.
 var (
 	SSHSensorTypeOutgoing = "Session-Outgoing-packet"
 	SSHSensorTypeIncoming = "Session-Incoming-packet"
 )
 
+// Config defines the configuration passed in to create a ssh connection.
 type Config struct {
 	Key    *PrivateKey `toml:"key"`
 	Port   string      `toml:"port"`
@@ -50,20 +53,20 @@ func generateKey() (*PrivateKey, error) {
 		return nil, err
 	}
 
-	if err := priv.Validate(); err != nil {
-		log.Errorf("Validation failed: %s", err.Error())
-		return nil, err
+	if cerr := priv.Validate(); cerr != nil {
+		log.Errorf("Validation failed: %s", cerr.Error())
+		return nil, cerr
 	}
 
-	priv_der := x509.MarshalPKCS1PrivateKey(priv)
+	privder := x509.MarshalPKCS1PrivateKey(priv)
 
-	priv_blk := pem.Block{
+	privblk := pem.Block{
 		Type:    "RSA PRIVATE KEY",
 		Headers: nil,
-		Bytes:   priv_der,
+		Bytes:   privder,
 	}
 
-	privateBytes := pem.EncodeToMemory(&priv_blk)
+	privateBytes := pem.EncodeToMemory(&privblk)
 
 	private, err := ssh.ParsePrivateKey(privateBytes)
 	if err != nil {
@@ -73,10 +76,12 @@ func generateKey() (*PrivateKey, error) {
 	return &PrivateKey{private}, nil
 }
 
+// PrivateKey holds the ssh.Signer instance to unsign received data.
 type PrivateKey struct {
 	ssh.Signer
 }
 
+// UnmarshalText unmarshalls the giving text as the Signers data.
 func (t *PrivateKey) UnmarshalText(data []byte) (err error) {
 	keyFile := string(data)
 
@@ -97,24 +102,25 @@ func (t *PrivateKey) UnmarshalText(data []byte) (err error) {
 	return err
 }
 
+// Listen initializes the ssh connection processes.
 // can we do something with:
 // https://github.com/golang/crypto/blob/master/ssh/agent/forward.go
-
+//
 // we have toml with config
 // so we can use this func with toml configurattion
 // toml.PrimitiveDecode(primitive, &SSHConfig{})
 // we don't need address anymore
-
+//
 // how to pass the pusher and director
 // Maybe just have a Listener() function that will return the listener?
-
+//
 // and how will this fit in the newer solution?
-
+//
 // also we don't want the proxy listener to listen, but have a custom listener interface
 // that we can swap. So we can use for emxapl cowrie as well, but also our raw stack
-
+//
 // TODO: Change amount of params.
-func Listen(address string, d *director.Director, p *pushers.Pusher, primitive toml.Primitive) (net.Listener, error) {
+func Listen(address string, d *director.Director, p *pushers.Pusher, events *pushers.EventDelivery, primitive toml.Primitive) (net.Listener, error) {
 	c := Config{
 		Key:    nil,
 		Port:   ":8022",
@@ -138,17 +144,19 @@ func Listen(address string, d *director.Director, p *pushers.Pusher, primitive t
 	}
 
 	return &Listener{
-		proxies.NewProxyListener(l, d, p),
+		proxies.NewProxyListener(l, d, p, events),
 		&c,
 	}, nil
 }
 
+// Listener defines a custom Listener for handling ssh connections.
 type Listener struct {
 	*proxies.ProxyListener
 
 	c *Config
 }
 
+// Accept calls the internal accept method for the underline ProxyListener.
 func (l *Listener) Accept() (net.Conn, error) {
 	conn, err := l.ProxyListener.Accept()
 	if err != nil {
@@ -159,14 +167,16 @@ func (l *Listener) Accept() (net.Conn, error) {
 	return &Conn{conn.(*proxies.ProxyConn), l.c}, err
 }
 
+// Conn defines a custom connection for handling ssh proxying.
 type Conn struct {
 	*proxies.ProxyConn
 
 	c *Config
 }
 
+// Proxy setsup the needed recorders to record ssh connection details.
 func (p *Conn) Proxy() error {
-	recorder := NewSSHRecorder(p.Pusher)
+	recorder := NewSSHRecorder(p.Pusher, p.Event)
 
 	rs := recorder.NewSession(p.ProxyConn)
 
@@ -180,7 +190,7 @@ func (p *Conn) Proxy() error {
 
 	err := c2Conn.Handshake2(p.Server.RemoteAddr().String(), &c2Config)
 	if err != nil {
-		log.Error("Client handshake failed: %s.", err.Error)
+		log.Errorf("Client handshake failed: %s.", err.Error())
 		return err
 	}
 
@@ -203,14 +213,14 @@ func (p *Conn) Proxy() error {
 			username = conn.User()
 			password = string(password2)
 
-			err := c2Conn.Authorize2(&c2Config)
-			if err == nil {
-				return nil, err
-			} else if err == io.EOF {
+			cerr := c2Conn.Authorize2(&c2Config)
+			if cerr == nil {
+				return nil, cerr
+			} else if cerr == io.EOF {
 				// TODO: How to handle client c2conn close? Server conn should be closed as well
 				// close server connection
 				// defer p.Close()
-			} else if _, ok := err.(syscall.Errno); ok {
+			} else if _, ok := cerr.(syscall.Errno); ok {
 				// TODO: How to handle client c2conn close? Server conn should be closed as well
 				// close server connection
 				// defer p.Close()
@@ -259,10 +269,10 @@ func (p *Conn) Proxy() error {
 			return err2
 		}
 
-		channel, requests, err := newChannel.Accept()
-		if err != nil {
-			log.Error("Could not accept server channel: ", err)
-			return err
+		channel, requests, cerr := newChannel.Accept()
+		if cerr != nil {
+			log.Error("Could not accept server channel: ", cerr)
+			return cerr
 		}
 
 		channelID := uuid.NewV4()
@@ -288,9 +298,9 @@ func (p *Conn) Proxy() error {
 					break
 				}
 
-				b, err := dst.SendRequest(req.Type, req.WantReply, req.Payload)
+				b, cerr := dst.SendRequest(req.Type, req.WantReply, req.Payload)
 				if err != nil {
-					log.Error("Reply Error", err)
+					log.Error("Reply Error", cerr)
 				}
 
 				if req.WantReply {
@@ -299,9 +309,9 @@ func (p *Conn) Proxy() error {
 
 				data := map[string]interface{}{"name": req.Type, "payload": req.Payload}
 
-				pack, err := json.Marshal(data)
-				if err != nil {
-					log.Error("Unable to Marshal Payload Channel Request Type", err)
+				pack, cerr := json.Marshal(data)
+				if cerr != nil {
+					log.Error("Unable to Marshal Payload Channel Request Type", cerr)
 				} else {
 					rs.Data("Session-RequestType-packet", channelID, pack)
 				}
@@ -337,10 +347,12 @@ func (p *Conn) Proxy() error {
 	return err
 }
 
+// NewSSHRecorderStream returns a new ssh recorder stream.
 func NewSSHRecorderStream(sensor string, rs *SSHRecorderSession /*meta, */, channelID uuid.UUID, username, password string, r io.ReadCloser) io.ReadCloser {
 	return &SSHPacketRecorder{sensor: sensor, rs: rs, channelID: channelID, ReadCloser: r, username: username, password: password, time: time.Now()}
 }
 
+// SSHPacketRecorder defines a custom packet recorder for ssh connections
 type SSHPacketRecorder struct {
 	rs *SSHRecorderSession
 	io.ReadCloser
@@ -353,16 +365,19 @@ type SSHPacketRecorder struct {
 	buffer    bytes.Buffer
 }
 
+// Read reads the internal data from the underline reader.
 func (lr *SSHPacketRecorder) Read(p []byte) (n int, err error) {
 	n, err = lr.ReadCloser.Read(p)
 	lr.rs.Data(lr.sensor, lr.channelID, p[:n])
 	return n, err
 }
 
+// String returns the string version of the internal recorder buffer.
 func (lr *SSHPacketRecorder) String() string {
 	return lr.buffer.String()
 }
 
+// Close closes the underline reader.
 func (lr *SSHPacketRecorder) Close() error {
 	return lr.ReadCloser.Close()
 }

--- a/proxies/ssh/ssh_recorder.go
+++ b/proxies/ssh/ssh_recorder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/satori/go.uuid"
 )
 
+// SSHAction defines a action for the SSH connection stream.
 type SSHAction struct {
 	Time        time.Time         `json:"date"`
 	ReceiveDate time.Time         `json:"receive_date"`
@@ -31,16 +32,20 @@ type SSHAction struct {
 	Meta        map[string]string `json:"meta,omitempty"`
 }
 
-// this is the global recorder
-func NewSSHRecorder(p *pushers.Pusher) *SSHRecorder {
+// NewSSHRecorder returns a new instance of the SSHRecorder.
+func NewSSHRecorder(p *pushers.Pusher, e *pushers.EventDelivery) *SSHRecorder {
 	// contains info about the container
-	return &SSHRecorder{p}
+	return &SSHRecorder{p, e}
 }
 
+// SSHRecorder defines a recorder for handling ssh connections.
 type SSHRecorder struct {
 	*pushers.Pusher
+	events *pushers.EventDelivery
 }
 
+// SSHRecorderSession defines a struct to use the underline SSHRecorder for a giving
+// ssh session.
 type SSHRecorderSession struct {
 	r         *SSHRecorder
 	seq       int
@@ -52,27 +57,34 @@ type SSHRecorderSession struct {
 	password  string
 }
 
+// NewSession creates a new session session recorder.
 func (r *SSHRecorder) NewSession(c *proxies.ProxyConn) *SSHRecorderSession {
 	sessionID := uuid.NewV4()
 	startDate := time.Now()
 	return &SSHRecorderSession{conn: c, sessionID: sessionID, seq: 0, r: r, startDate: startDate}
 }
 
+// Connect records the connect operation for the underline ssh connection.
 func (rs *SSHRecorderSession) Connect() {
 	rs.r.Push("ssh", "connect", rs.conn.Container.Name(), rs.sessionID.String(), &SSHAction{ContainerID: rs.conn.Container.Name(), RemoteAddr: rs.conn.RemoteHost(), SessionID: rs.sessionID.String(), Sequence: rs.seq, Sensor: "connect", Time: time.Now(), StartDate: rs.startDate, Payload: nil})
 	rs.seq++
 }
 
+// Start records the start operation for the underline ssh connection.
 func (rs *SSHRecorderSession) Start() {
 	rs.r.Push("ssh", "Session-Open-Packet", rs.conn.Container.Name(), rs.sessionID.String(), &SSHAction{ContainerID: rs.conn.Container.Name(), RemoteAddr: rs.conn.RemoteHost(), SessionID: rs.sessionID.String(), Sequence: rs.seq, Sensor: "Session-Open-packet", Time: time.Now(), StartDate: rs.startDate, Payload: nil})
 	rs.seq++
 }
 
+// AuthorizationPublicKey records the publickey authroization operation for the
+// underline ssh connection.
 func (rs *SSHRecorderSession) AuthorizationPublicKey(username, keyType string, key []byte) {
 	rs.r.Push("ssh", "Session-Authentication-PublicKey", rs.conn.Container.Name(), rs.sessionID.String(), &SSHAction{ContainerID: rs.conn.Container.Name(), ChannelID: "", Username: username, KeyType: keyType, Key: fmt.Sprintf("%x", key), RemoteAddr: rs.conn.RemoteHost(), SessionID: rs.sessionID.String(), Sequence: rs.seq, Sensor: "Session-Authentication-PublicKey", Time: time.Now(), StartDate: rs.startDate, Payload: nil})
 	rs.seq++
 }
 
+// AuthorizationSuccess records the publickey authroization success operation for
+// the underline ssh connection.
 func (rs *SSHRecorderSession) AuthorizationSuccess(username, password, client string) {
 	rs.r.Push("ssh", "Session-Authentication-Success", rs.conn.Container.Name(), rs.sessionID.String(), &SSHAction{ContainerID: rs.conn.Container.Name(), ChannelID: "", Username: username, Password: password, RemoteAddr: rs.conn.RemoteHost(), SessionID: rs.sessionID.String(), Sequence: rs.seq, Sensor: "Session-Authentication-Success", Time: time.Now(), StartDate: rs.startDate, Client: client, Payload: nil})
 	rs.seq++
@@ -80,11 +92,14 @@ func (rs *SSHRecorderSession) AuthorizationSuccess(username, password, client st
 	rs.password = password
 }
 
+// AuthorizationFailed records the publickey authroization failure operation for
+// the underline ssh connection.
 func (rs *SSHRecorderSession) AuthorizationFailed(username, password, client string) {
 	rs.r.Push("ssh", "Session-Authentication-Failed", rs.conn.Container.Name(), rs.sessionID.String(), &SSHAction{ContainerID: rs.conn.Container.Name(), ChannelID: "", Username: username, Password: password, RemoteAddr: rs.conn.RemoteHost(), SessionID: rs.sessionID.String(), Sequence: rs.seq, Sensor: "Session-Authentication-Failed", Time: time.Now(), StartDate: rs.startDate, Client: client, Payload: nil})
 	rs.seq++
 }
 
+// Data records the ssh data payload operation for the underline ssh connection.
 func (rs *SSHRecorderSession) Data(sensor string, channelID uuid.UUID, payload []byte) {
 	data := make([]byte, len(payload))
 	copy(data, payload)
@@ -92,26 +107,31 @@ func (rs *SSHRecorderSession) Data(sensor string, channelID uuid.UUID, payload [
 	rs.seq++
 }
 
+// CustomData records the ssh custom data payload operation for the underline ssh connection.
 func (rs *SSHRecorderSession) CustomData(tag string, payload []byte) {
 	rs.r.Push("ssh", tag, rs.conn.Container.Name(), rs.sessionID.String(), &SSHAction{ContainerID: rs.conn.Container.Name(), RemoteAddr: rs.conn.RemoteHost(), Username: rs.username, Password: rs.password, SessionID: rs.sessionID.String(), Sequence: 0, Sensor: tag, Time: time.Now(), StartDate: rs.startDate, Payload: payload})
 }
 
+// Stop records the stop  call for the underline ssh connection.
 func (rs *SSHRecorderSession) Stop() {
 	rs.r.Push("ssh", "Session-Closed-packet", rs.conn.Container.Name(), rs.sessionID.String(), &SSHAction{ContainerID: rs.conn.Container.Name(), RemoteAddr: rs.conn.RemoteHost(), Username: rs.username, Password: rs.password, SessionID: rs.sessionID.String(), Sequence: rs.seq, Sensor: "Session-Closed-packet", Time: time.Now(), StartDate: rs.startDate, EndDate: time.Now(), Payload: nil})
 	rs.seq++
 }
 
+// SSHRecordSessionWriter defines a writer for the ssh session.
 type SSHRecordSessionWriter struct {
 	*SSHRecorderSession
 
 	tag string
 }
 
+// Write writes the provided bytes into the underline session recorder.
 func (r *SSHRecordSessionWriter) Write(b []byte) (int, error) {
 	r.CustomData(r.tag, b)
 	return len(b), nil
 }
 
+// NewSSHRecordSessionWriter returns a new instance of a session write recorder.
 func NewSSHRecordSessionWriter(tag string, r *SSHRecorderSession) *SSHRecordSessionWriter {
 	return &SSHRecordSessionWriter{r, tag}
 }

--- a/proxies/ssh/ssh_recorder.go
+++ b/proxies/ssh/ssh_recorder.go
@@ -33,7 +33,7 @@ type SSHAction struct {
 }
 
 // NewSSHRecorder returns a new instance of the SSHRecorder.
-func NewSSHRecorder(p *pushers.Pusher, e *pushers.EventDelivery) *SSHRecorder {
+func NewSSHRecorder(p *pushers.Pusher, e pushers.Events) *SSHRecorder {
 	// contains info about the container
 	return &SSHRecorder{p, e}
 }
@@ -41,7 +41,7 @@ func NewSSHRecorder(p *pushers.Pusher, e *pushers.EventDelivery) *SSHRecorder {
 // SSHRecorder defines a recorder for handling ssh connections.
 type SSHRecorder struct {
 	*pushers.Pusher
-	events *pushers.EventDelivery
+	events pushers.Events
 }
 
 // SSHRecorderSession defines a struct to use the underline SSHRecorder for a giving

--- a/proxies/tcp.go
+++ b/proxies/tcp.go
@@ -2,10 +2,14 @@ package proxies
 
 import "io"
 
+// TCPProxyConn defines a struct which embeds the ProxyConn and provides
+// the needed tcp operation call to proxy tcp connections.
 type TCPProxyConn struct {
 	ProxyConn
 }
 
+// Proxy defines a function to copy connection details from the server to a
+// underline connection.
 func (p TCPProxyConn) Proxy() error {
 	defer func() {
 		p.Close()

--- a/pushers/events.go
+++ b/pushers/events.go
@@ -1,0 +1,30 @@
+package pushers
+
+import (
+	"github.com/honeytrap/honeytrap/pushers/message"
+)
+
+// EventDelivery defines a struct which embodies a delivery system which allows
+// events to be piped down to a pusher library.
+type EventDelivery struct {
+	sync Channel
+}
+
+// NewEventDelivery returns a new EventDelivery instance which is used to deliver
+// events.
+func NewEventDelivery(channel Channel) *EventDelivery {
+	return &EventDelivery{sync: channel}
+}
+
+// Deliver adds the giving event into the provided message.Channel for the delivery
+func (d *EventDelivery) Deliver(ev message.Event) {
+	d.sync.Send([]*message.PushMessage{
+		{
+			Sensor:      ev.Sensor,
+			Category:    ev.Category,
+			SessionID:   ev.SessionID,
+			ContainerID: ev.ContainerID,
+			Data:        ev,
+		},
+	})
+}

--- a/pushers/events.go
+++ b/pushers/events.go
@@ -1,8 +1,38 @@
 package pushers
 
 import (
+	"time"
+
 	"github.com/honeytrap/honeytrap/pushers/message"
 )
+
+// Events defines an interface which exposes a method for the delivery of message.Event
+// object.
+type Events interface {
+	Deliver(message.Event)
+}
+
+// TokenedEventDelivery defines a custom event delivery type which wraps the
+// EventDelivery and sets the internal token value for the events passed in.
+type TokenedEventDelivery struct {
+	*EventDelivery
+	Token string
+}
+
+// NewTokenedEventDelivery returns a new TokenedEventDelivery instanc.
+func NewTokenedEventDelivery(token string, channel Channel) *TokenedEventDelivery {
+	return &TokenedEventDelivery{
+		EventDelivery: NewEventDelivery(channel),
+		Token:         token,
+	}
+}
+
+// Deliver delivers the underline event object to the underline EventDelivery
+// object.
+func (a TokenedEventDelivery) Deliver(ev message.Event) {
+	ev.Token = a.Token
+	a.Deliver(ev)
+}
 
 // EventDelivery defines a struct which embodies a delivery system which allows
 // events to be piped down to a pusher library.
@@ -18,6 +48,9 @@ func NewEventDelivery(channel Channel) *EventDelivery {
 
 // Deliver adds the giving event into the provided message.Channel for the delivery
 func (d *EventDelivery) Deliver(ev message.Event) {
+	// Set the time for the event
+	ev.Time = time.Now()
+
 	d.sync.Send([]*message.PushMessage{
 		{
 			Sensor:      ev.Sensor,

--- a/pushers/filters.go
+++ b/pushers/filters.go
@@ -34,8 +34,14 @@ func CategoryFilterFunc(rx *regexp.Regexp, message *message.PushMessage) bool {
 
 // EventFilterFunc defines a function to validate a PushMessage.Category value
 // based on a provided regular expression.
-func EventFilterFunc(rx *regexp.Regexp, message *message.PushMessage) bool {
-	return rx.MatchString("")
+func EventFilterFunc(rx *regexp.Regexp, m *message.PushMessage) bool {
+	if event, ok := m.Data.(message.Event); ok {
+		return rx.MatchString(event.Sensor)
+	}
+
+	// TODO: Decide if we should return false when this is called for messages
+	// not containing event objects.
+	return true
 }
 
 //==========================================================================================

--- a/pushers/honeytrap/honeytrap.go
+++ b/pushers/honeytrap/honeytrap.go
@@ -15,13 +15,15 @@ import (
 
 var log = logging.MustGetLogger("honeytrap:channels:honeytrap")
 
-type HoneytrapChannel struct {
+// TrapChannel defines a struct which implmenets the pushers.Channel
+// interface for delivery honeytrap special messages.
+type TrapChannel struct {
 	client *api.Client
 }
 
-// Unmarshal attempts to unmarshal the provided value into the giving
+// UnmarshalConfig attempts to unmarshal the provided value into the giving
 // HoneytrapChannel.
-func (hc *HoneytrapChannel) UnmarshalConfig(m interface{}) error {
+func (hc *TrapChannel) UnmarshalConfig(m interface{}) error {
 	conf, ok := m.(map[string]interface{})
 	if !ok {
 		return errors.New("Expected to receive a map")
@@ -43,7 +45,8 @@ func (hc *HoneytrapChannel) UnmarshalConfig(m interface{}) error {
 	return nil
 }
 
-func (hc HoneytrapChannel) Send(messages []*message.PushMessage) {
+// Send delivers all messages to the underline connection.
+func (hc TrapChannel) Send(messages []*message.PushMessage) {
 	// TODO:
 	// req, err := hc.client.NewRequest("POST", "v1/action/{sensor}/{type}", actions)
 
@@ -66,7 +69,6 @@ func (hc HoneytrapChannel) Send(messages []*message.PushMessage) {
 			log.Errorf("HoneytrapChannel: Error while preparing request: %s", err.Error())
 			continue
 		}
-
 		var resp *http.Response
 		if resp, err = hc.client.Do(req, nil); err != nil {
 			log.Errorf("HoneytrapChannel: Error while sending message: %s", err.Error())

--- a/pushers/message/message.go
+++ b/pushers/message/message.go
@@ -1,6 +1,10 @@
 package message
 
-// Message defines a struct which contains specific data relating to
+import "fmt"
+
+//====================================================================================
+
+// PushMessage defines a struct which contains specific data relating to
 // different messages to provide Push notifications for the pusher api.
 type PushMessage struct {
 	Sensor      string
@@ -9,3 +13,64 @@ type PushMessage struct {
 	ContainerID string
 	Data        interface{}
 }
+
+//====================================================================================
+
+// EventType defines a int type for all event types available.
+type EventType int
+
+// contains different sets of possible events type.
+const (
+	// Process based events.
+	ProcessBegin = iota + 1
+	ProcessEnd
+
+	Ping
+
+	NewConnection
+	ConnectionStarted
+	ConnectionClosed
+	ConnectionRequest
+	ConnectionResponse
+	ConnectionError
+
+	ServiceStarted
+	ServiceEnded
+
+	// Container based events.
+	ContainerClone
+	ContainerStarted
+	ContainerFrozen
+	ContainerUnfrozen
+	ContainerStopped
+	ContainerTarBackup
+	ContainerDataPacket
+	ContainerDataCheckpoint
+
+	// SSH based events.
+	SSHSessionBegin
+	SSHSessionEnd
+
+	// Authentication events.
+	Login = iota + 30
+	Logout
+)
+
+// Event defines a struct which contains definitive details about the operation of
+// a giving event.
+type Event struct {
+	Sensor      string                 `json:"sensor"`
+	Category    string                 `json:"category"`
+	Type        EventType              `json:"event_type"`
+	Data        interface{}            `json:"data"`
+	Details     map[string]interface{} `json:"details"`
+	SessionID   string                 `json:"session_id,omitempty"`
+	ContainerID string                 `json:"container_id,omitempty"`
+}
+
+// String returns a stringified version of the event.
+func (e Event) String() string {
+	return fmt.Sprintf("Event %d occured with for Sensor[%q] in Category[%q]. Data[%#q] - Detail[%#q]", e.Type, e.Sensor, e.Category, e.Data, e.Details)
+}
+
+//====================================================================================

--- a/pushers/message/message.go
+++ b/pushers/message/message.go
@@ -1,6 +1,9 @@
 package message
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 //====================================================================================
 
@@ -60,7 +63,11 @@ const (
 // a giving event.
 type Event struct {
 	Sensor      string                 `json:"sensor"`
+	Time        time.Time              `json:"time"`
+	Token       string                 `json:"token,omitempty"`
 	Category    string                 `json:"category"`
+	HostAddr    string                 `json:"host_addr"`
+	LocalAddr   string                 `json:"local_addr"`
 	Type        EventType              `json:"event_type"`
 	Data        interface{}            `json:"data"`
 	Details     map[string]interface{} `json:"details"`

--- a/pushers/pusher.go
+++ b/pushers/pusher.go
@@ -101,7 +101,7 @@ func New(conf *config.Config) *Pusher {
 
 			backends[key] = fchan
 		case "honeytrap":
-			var htrap honeytrap.HoneytrapChannel
+			var htrap honeytrap.TrapChannel
 			if err := htrap.UnmarshalConfig(backend); err != nil {
 				log.Errorf("Error initializing channel: %s", err.Error())
 				continue

--- a/pushers/pusher.go
+++ b/pushers/pusher.go
@@ -12,17 +12,41 @@ import (
 	"github.com/honeytrap/honeytrap/pushers/slack"
 )
 
+//=======================================================================================================
+
 // Waiter exposes a method to call a wait method to allow a channel finish it's
 // operation.
 type Waiter interface {
 	Wait()
 }
 
+//=======================================================================================================
+
 // Channel defines a interface which exposes a single method for delivering
 // PushMessages to a giving underline service.
 type Channel interface {
 	Send([]*message.PushMessage)
 }
+
+//=======================================================================================================
+
+// ProxyPusher defines a decorator for the Pusher object which decorates it as a
+// Channel.
+type ProxyPusher struct {
+	pusher *Pusher
+}
+
+// NewProxyPusher returns a new instance of a ProxyPusher
+func NewProxyPusher(p *Pusher) *ProxyPusher {
+	return &ProxyPusher{pusher: p}
+}
+
+// Send delivers the messages to the underline Pusher instance.
+func (p ProxyPusher) Send(messages []*message.PushMessage) {
+	p.pusher.send(messages)
+}
+
+//=======================================================================================================
 
 // Pusher defines a struct which implements a pusher to manage the loading and
 // delivery of message.PushMessage.
@@ -209,3 +233,5 @@ func (p *Pusher) add(a *message.PushMessage) {
 		p.flush()
 	}
 }
+
+//=======================================================================================================

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -30,7 +30,7 @@ type Honeytrap struct {
 	config   *config.Config
 	director *director.Director
 	pusher   *pushers.Pusher
-	events   *pushers.EventDelivery
+	events   pushers.Events
 }
 
 // ServeFunc defines the function called to handle internal server details.
@@ -39,7 +39,7 @@ type ServeFunc func() error
 // New returns a new instance of a Honeytrap struct.
 func New(conf *config.Config) *Honeytrap {
 	pusher := pushers.New(conf)
-	events := pushers.NewEventDelivery(pushers.NewProxyPusher(pusher))
+	events := pushers.NewTokenedEventDelivery(conf.Token, pushers.NewProxyPusher(pusher))
 	director := director.New(conf, events)
 
 	return &Honeytrap{conf, director, pusher, events}

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -3,58 +3,69 @@ package server
 import (
 	"net"
 
-	_ "net/http/pprof"
+	_ "net/http/pprof" // Add pprof tooling
 
 	"github.com/BurntSushi/toml"
 	config "github.com/honeytrap/honeytrap/config"
 	director "github.com/honeytrap/honeytrap/director"
 
 	proxies "github.com/honeytrap/honeytrap/proxies"
-	_ "github.com/honeytrap/honeytrap/proxies/ssh"
+	_ "github.com/honeytrap/honeytrap/proxies/ssh" // TODO: Add comment
 
 	pushers "github.com/honeytrap/honeytrap/pushers"
-	// _ "github.com/honeytrap/honeytrap/pushers/elasticsearch"
-	// _ "github.com/honeytrap/honeytrap/pushers/honeytrap"
-	_ "github.com/honeytrap/honeytrap/pushers/slack"
+	// _ "github.com/Honeytrap/Honeytrap/pushers/elasticsearch"
+	// _ "github.com/Honeytrap/Honeytrap/pushers/Honeytrap"
+	"github.com/honeytrap/honeytrap/pushers/message"
 
 	utils "github.com/honeytrap/honeytrap/utils"
 
 	logging "github.com/op/go-logging"
 )
 
-var log = logging.MustGetLogger("honeytrap")
+var log = logging.MustGetLogger("Honeytrap")
 
-type honeytrap struct {
+// Honeytrap defines a struct which coordinates the internal logic for the honeytrap
+// container infrastructure.
+type Honeytrap struct {
 	config   *config.Config
 	director *director.Director
 	pusher   *pushers.Pusher
+	events   *pushers.EventDelivery
 }
 
+// ServeFunc defines the function called to handle internal server details.
 type ServeFunc func() error
 
-func New(conf *config.Config) *honeytrap {
-	director := director.New(conf)
+// New returns a new instance of a Honeytrap struct.
+func New(conf *config.Config) *Honeytrap {
 	pusher := pushers.New(conf)
-	return &honeytrap{conf, director, pusher}
+	events := pushers.NewEventDelivery(pushers.NewProxyPusher(pusher))
+	director := director.New(conf, events)
+
+	return &Honeytrap{conf, director, pusher, events}
 }
 
-func (hc *honeytrap) startAgentServer() {
+func (hc *Honeytrap) startAgentServer() {
 	// as := proxies.NewAgentServer(hc.director, hc.pusher, hc.config)
 	// go as.ListenAndServe()
 }
 
-type ListenFunc func(string, *director.Director, *pushers.Pusher, *config.Config) (net.Listener, error)
+// ListenFunc defines a function type which returns a net.Listener specific for the
+// use of its argument and for the reception of net connections.
+type ListenFunc func(string, *director.Director, *pushers.Pusher, *pushers.EventDelivery, *config.Config) (net.Listener, error)
 
+// ListenerConfig defines a struct for holding configuration fields for a Listener
+// builder.
 type ListenerConfig struct {
 	fn      ListenFunc
 	address string
 }
 
-func (hc *honeytrap) startPusher() {
+func (hc *Honeytrap) startPusher() {
 	hc.pusher.Start()
 }
 
-func (hc *honeytrap) startProxies() {
+func (hc *Honeytrap) startProxies() {
 	for _, primitive := range hc.config.Services {
 		st := struct {
 			Service string `toml:"service"`
@@ -69,11 +80,31 @@ func (hc *honeytrap) startProxies() {
 		if serviceFn, ok := proxies.Get(st.Service); ok {
 			log.Debugf("Listener starting: %s", st.Port)
 
-			service, err := serviceFn(st.Port, hc.director, hc.pusher, primitive)
+			service, err := serviceFn(st.Port, hc.director, hc.pusher, hc.events, primitive)
 			if err != nil {
 				log.Errorf("Error in service: %s: %s", st.Service, err.Error())
+
+				hc.events.Deliver(message.Event{
+					Sensor:   st.Service,
+					Category: "Services",
+					Type:     message.ServiceStarted,
+					Details: map[string]interface{}{
+						"primitive": primitive,
+						"error":     err.Error(),
+					},
+				})
+
 				continue
 			}
+
+			hc.events.Deliver(message.Event{
+				Sensor:   st.Service,
+				Category: "Services",
+				Type:     message.ServiceStarted,
+				Details: map[string]interface{}{
+					"primitive": primitive,
+				},
+			})
 
 			/*
 				if err := toml.PrimitiveDecode(primitive, &service); err != nil {
@@ -154,7 +185,8 @@ func (hc *honeytrap) startProxies() {
 	*/
 }
 
-func (hc *honeytrap) Serve() {
+// Serve initializes and starts the internal logic for the Honeytrap instance.
+func (hc *Honeytrap) Serve() {
 
 	hc.startPusher()
 	hc.startProxies()

--- a/server/ping.go
+++ b/server/ping.go
@@ -1,13 +1,23 @@
 package server
 
-import "time"
+import (
+	"time"
 
-func (hc *honeytrap) ping() error {
-	hc.pusher.Push("honeytrap", "ping", "", "", nil)
+	"github.com/honeytrap/honeytrap/pushers/message"
+)
+
+// ping delivers a ping event to the server indicate it's alive.
+func (hc *Honeytrap) ping() error {
+	hc.events.Deliver(message.Event{
+		Sensor:   "Ping",
+		Category: "Server",
+		Type:     message.Ping,
+	})
 	return nil
 }
 
-func (hc *honeytrap) startPing() {
+// startPing initializes the ping runner.
+func (hc *Honeytrap) startPing() {
 	go func() {
 		for {
 			log.Debug("Yep, still alive")

--- a/server/recover.go
+++ b/server/recover.go
@@ -1,7 +1,11 @@
 package server
 
-import "runtime"
+import (
+	"runtime"
+)
 
+// RecoverHandler defines a function which calls the provided ServeFunc
+// within a protective recover() function.
 func RecoverHandler(serveFn ServeFunc) error {
 	defer func() {
 		if err := recover(); err != nil {

--- a/server/stats.go
+++ b/server/stats.go
@@ -1,17 +1,20 @@
 package server
 
 import (
-	web "github.com/honeytrap/honeytrap-web"
 	"net/http"
 
+	web "github.com/honeytrap/honeytrap-web"
+
 	"fmt"
+
 	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/fatih/color"
 	// logging "github.com/op/go-logging"
 	"os"
 )
 
-func (hc *honeytrap) startStatsServer() {
+// startStatsServer starts the http server for handling request.
+func (hc *Honeytrap) startStatsServer() {
 	log.Infof("Stats server Listening on port: %s", hc.config.Web.Port)
 
 	staticHandler := http.FileServer(
@@ -32,6 +35,7 @@ func (hc *honeytrap) startStatsServer() {
 		log.Debug("Using static file path: ", hc.config.Web.Path)
 
 		// check local css first
+		// TODO: What is this for and why are we assigning here.
 		staticHandler = http.FileServer(http.Dir(hc.config.Web.Path))
 	}
 


### PR DESCRIPTION
PR adds the new `events` API. It adds basic level calls and adjusts all the provided proxies to include it's instance as to allow future use of the provided instance in reporting events. This will allow us to initially review and adjust the parameters for the event model.



Related to issue #18 
Also #27 , #20 