### PR TITLE
Update director to use package level director store

### DIFF
--- a/director/cowriedirector/cowrie.go
+++ b/director/cowriedirector/cowrie.go
@@ -28,6 +28,7 @@ const (
 var (
 	dailTimeout = 5 * time.Second
 	log         = logging.MustGetLogger("honeytrap:director:cowrie")
+	_           = director.RegisterDirector("cowrie", NewWith)
 )
 
 // Director defines a central structure which creates/retrieves Container
@@ -40,6 +41,11 @@ type Director struct {
 	containers     map[string]director.Container
 	globalCommands process.SyncProcess
 	globalScripts  process.SyncScripts
+}
+
+// NewWith returns a new instance of the Director.
+func NewWith(config *config.Config, events pushers.Channel) director.Director {
+	return New(config, events)
 }
 
 // New returns a new instance of the Director.

--- a/director/cowriedirector/cowrie.go
+++ b/director/cowriedirector/cowrie.go
@@ -44,8 +44,8 @@ type Director struct {
 }
 
 // NewWith returns a new instance of the Director.
-func NewWith(config *config.Config, events pushers.Channel) director.Director {
-	return New(config, events)
+func NewWith(config *config.Config, events pushers.Channel) (director.Director, error) {
+	return New(config, events), nil
 }
 
 // New returns a new instance of the Director.

--- a/director/iodirector/iodirector.go
+++ b/director/iodirector/iodirector.go
@@ -43,8 +43,8 @@ type Director struct {
 }
 
 // NewWith returns a new instance of the Director.
-func NewWith(config *config.Config, events pushers.Channel) director.Director {
-	return New(config, events)
+func NewWith(config *config.Config, events pushers.Channel) (director.Director, error) {
+	return New(config, events), nil
 }
 
 // New returns a new instance of the Director.

--- a/director/iodirector/iodirector.go
+++ b/director/iodirector/iodirector.go
@@ -27,6 +27,7 @@ const (
 var (
 	dailTimeout = 5 * time.Second
 	log         = logging.MustGetLogger("honeytrap:director:io")
+	_           = director.RegisterDirector("io", NewWith)
 )
 
 // Director defines a central structure which creates/retrieves Container
@@ -39,6 +40,11 @@ type Director struct {
 	containers     map[string]director.Container
 	globalCommands process.SyncProcess
 	globalScripts  process.SyncScripts
+}
+
+// NewWith returns a new instance of the Director.
+func NewWith(config *config.Config, events pushers.Channel) director.Director {
+	return New(config, events)
 }
 
 // New returns a new instance of the Director.

--- a/director/lxcdirector/director_linux.go
+++ b/director/lxcdirector/director_linux.go
@@ -16,10 +16,8 @@ import (
 	"github.com/honeytrap/namecon"
 )
 
-const (
-	// DirectorKey defines the key used to choose this giving director.
-	DirectorKey = "lxc"
-	_           = director.RegisterDirector("lxc", NewWith)
+var (
+	_ = director.RegisterDirector("lxc", NewWith)
 )
 
 // Director defines a struct which handles the management of registered containers.
@@ -32,8 +30,8 @@ type Director struct {
 }
 
 // NewWith returns a new instance of the Director.
-func NewWith(config *config.Config, events pushers.Channel) director.Director {
-	return New(config, events)
+func NewWith(config *config.Config, events pushers.Channel) (director.Director, error) {
+	return New(config, events), nil
 }
 
 // New returns a new instance of a Director.

--- a/director/lxcdirector/director_linux.go
+++ b/director/lxcdirector/director_linux.go
@@ -19,6 +19,7 @@ import (
 const (
 	// DirectorKey defines the key used to choose this giving director.
 	DirectorKey = "lxc"
+	_           = director.RegisterDirector("lxc", NewWith)
 )
 
 // Director defines a struct which handles the management of registered containers.
@@ -28,6 +29,11 @@ type Director struct {
 	namer      namecon.Namer
 	m          sync.Mutex
 	containers map[string]director.Container
+}
+
+// NewWith returns a new instance of the Director.
+func NewWith(config *config.Config, events pushers.Channel) director.Director {
+	return New(config, events)
 }
 
 // New returns a new instance of a Director.

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -15,6 +15,9 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/honeytrap/honeytrap/config"
 	"github.com/honeytrap/honeytrap/director"
+	_ "github.com/honeytrap/honeytrap/director/cowriedirector" // Registers slack backend.
+	_ "github.com/honeytrap/honeytrap/director/iodirector"     // Registers stdout backend.
+	_ "github.com/honeytrap/honeytrap/director/lxcdirector"    // Registers honeytrap backend.
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -15,9 +15,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/honeytrap/honeytrap/config"
 	"github.com/honeytrap/honeytrap/director"
-	"github.com/honeytrap/honeytrap/director/cowriedirector"
-	"github.com/honeytrap/honeytrap/director/iodirector"
-	"github.com/honeytrap/honeytrap/director/lxcdirector"
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 
@@ -61,17 +58,9 @@ func New(conf *config.Config) *Honeytrap {
 	// Initialize all channels within the provided config.
 	pushers.ChannelsFrom(conf, bus)
 
-	var dir director.Director
-
-	switch conf.Director {
-	case cowriedirector.DirectorKey:
-		dir = cowriedirector.New(conf, bus)
-	case iodirector.DirectorKey:
-		dir = iodirector.New(conf, bus)
-	case lxcdirector.DirectorKey:
-		dir = lxcdirector.New(conf, bus)
-	default:
-		panic(fmt.Sprintf("Unknown director type: %q", conf.Director))
+	dir, err := director.NewDirector(conf.Director, conf, bus)
+	if err != nil {
+		panic(fmt.Sprintf("Unknown director %q: %q", conf.Director, err))
 	}
 
 	manager := director.NewContainerConnections()


### PR DESCRIPTION
PR updates directors to use a package level store which allows us retrieve a new instance through a given name.
