### PR TITLE
Fix regex filter function

### DIFF
--- a/pushers/filters.go
+++ b/pushers/filters.go
@@ -74,9 +74,11 @@ func RegexFilterFunc(field string, expressions []string) FilterFunc {
 	return func(e event.Event) bool {
 		for _, rx := range matchers {
 			val := e.Get(field)
-			return rx.MatchString(val)
+			// Only return on successful match, continue loop otherwise
+			if rx.MatchString(val) {
+				return true
+			}
 		}
-
 		return false
 	}
 }


### PR DESCRIPTION
The regex filter function would only check for the first matcher in the config. This fix iterates through the for-loop until a match is found, and return false otherwise. 