### PR TITLE
Implemented support for Honeytrap Agent

### DIFF
--- a/listener/agent/agent.go
+++ b/listener/agent/agent.go
@@ -1,0 +1,290 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package agent
+
+import (
+	"encoding"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/fatih/color"
+	"github.com/honeytrap/honeytrap/listener"
+	logging "github.com/op/go-logging"
+)
+
+var log = logging.MustGetLogger("listeners/agent")
+
+var (
+	_ = listener.Register("agent", New)
+)
+
+type agentListener struct {
+	agentConfig
+
+	ch chan net.Conn
+
+	net.Listener
+}
+
+type agentConfig struct {
+	Addresses []net.Addr
+}
+
+func (sc *agentConfig) AddAddress(a net.Addr) {
+	sc.Addresses = append(sc.Addresses, a)
+}
+
+func New(options ...func(listener.Listener) error) (listener.Listener, error) {
+	ch := make(chan net.Conn)
+
+	l := agentListener{
+		agentConfig: agentConfig{},
+		ch:          ch,
+	}
+
+	for _, option := range options {
+		option(&l)
+	}
+
+	return &l, nil
+}
+
+type conn2 struct {
+	net.Conn
+
+	al *agentListener
+}
+
+func (c *conn2) Handshake() error {
+	buff := make([]byte, 2)
+
+	log.Debugf("Agent connecting from remote address: %s", c.RemoteAddr())
+
+	n, err := c.Read(buff[:])
+	if err != nil {
+		return err
+	}
+
+	size := binary.LittleEndian.Uint16(buff)
+
+	buff = make([]byte, size)
+	n, err = c.Read(buff[:])
+	if err != nil {
+		return err
+	}
+
+	h := Handshake{}
+
+	if err := h.UnmarshalBinary(buff[:n]); err != nil {
+		return err
+	}
+
+	fmt.Println("Handhake received")
+
+	p := HandshakeResponse{
+		c.al.Addresses,
+	}
+
+	if data, err := p.MarshalBinary(); err == nil {
+		buff := make([]byte, 2)
+		binary.LittleEndian.PutUint16(buff[0:2], uint16(len(data)))
+
+		c.Write(buff)
+		c.Write(data)
+	} else {
+		return err
+	}
+
+	return nil
+}
+
+func (ac conn2) send(o encoding.BinaryMarshaler) error {
+	data, err := o.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	buff := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buff[0:2], uint16(len(data)))
+
+	if _, err := ac.Conn.Write(buff); err != nil {
+		return err
+	}
+
+	if _, err := ac.Conn.Write(data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sl *agentListener) serv(c conn2) {
+	conns := Connections{}
+
+	if err := c.Handshake(); err == io.EOF {
+		return
+	} else if err != nil {
+		fmt.Println(color.RedString(err.Error()))
+		return
+	}
+
+	fmt.Println("Agent connected...")
+	defer fmt.Println("Agent disconnected...")
+
+	out := make(chan ReadWrite)
+	go func(ch chan ReadWrite) {
+		for p := range ch {
+			err := c.send(p)
+			if err != nil {
+				log.Error("Error marshaling hello: %s", err.Error())
+				break
+			}
+		}
+	}(out)
+
+	func(ch chan ReadWrite) {
+		for {
+			buff := make([]byte, 2)
+
+			n, err := c.Read(buff[:])
+			if err == io.EOF {
+				log.Errorf("REMCO EOF", err.Error())
+			} else if err != nil {
+				log.Errorf("REMCO ", err.Error())
+				return
+			}
+
+			size := binary.LittleEndian.Uint16(buff)
+
+			buff = make([]byte, size)
+			n, err = c.Read(buff[:])
+			if err != nil {
+				log.Errorf(err.Error())
+				return
+			}
+
+			if int(buff[0]) == TypeHello {
+				h := Hello{}
+
+				err := h.UnmarshalBinary(buff[:n])
+				if err != nil {
+					log.Errorf(err.Error())
+					return
+				}
+
+				ac := &agentConnection{
+					Laddr: h.Laddr,
+					Raddr: h.Raddr,
+					in:    make(chan []byte),
+					out:   ch,
+				}
+
+				conns = append(conns, ac)
+
+				sl.ch <- ac
+
+			} else if int(buff[0]) == TypeReadWrite {
+				r := ReadWrite{}
+
+				err := r.UnmarshalBinary(buff[:n])
+				if err != nil {
+					log.Errorf(err.Error())
+					return
+				}
+
+				conn := conns.Get(r.Laddr, r.Raddr)
+				if conn == nil {
+					continue
+				}
+
+				conn.in <- r.Payload
+			} else if int(buff[0]) == TypeEOF {
+				// read
+				fmt.Println("EOF")
+				r := EOF{}
+
+				err := r.UnmarshalBinary(buff[:n])
+				if err != nil {
+					log.Errorf(err.Error())
+					return
+				}
+
+				conn := conns.Get(r.Laddr, r.Raddr)
+				if conn == nil {
+					continue
+				}
+
+				// remove connection
+
+				conn.closed = true
+				close(conn.in)
+			} else if int(buff[0]) == TypePing {
+				log.Debugf("Received ping from agent: %s", c.RemoteAddr())
+			}
+		}
+	}(out)
+
+	return
+}
+
+func (sl *agentListener) Start() error {
+	l, err := net.Listen("tcp", ":1339")
+	if err != nil {
+		fmt.Println(color.RedString("Error starting listener: %s", err.Error()))
+		return err
+	}
+
+	log.Infof("Listener started: %s", ":1339")
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				log.Errorf("Error accepting connection: %s", err.Error())
+				continue
+			}
+
+			sl.serv(conn2{
+				c,
+				sl,
+			})
+		}
+	}()
+
+	return nil
+}
+
+func (sl *agentListener) Accept() (net.Conn, error) {
+	c := <-sl.ch
+	return c, nil
+}

--- a/listener/agent/conn2.go
+++ b/listener/agent/conn2.go
@@ -1,0 +1,132 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package agent
+
+import (
+	"encoding"
+	"encoding/binary"
+	"net"
+)
+
+func Conn2(c net.Conn) *conn2 {
+	return &conn2{c}
+}
+
+type conn2 struct {
+	net.Conn
+}
+
+func (c *conn2) Handshake() error {
+	return nil
+}
+
+func (ac *conn2) receive() (interface{}, error) {
+	buff := make([]byte, 1)
+
+	if _, err := ac.Conn.Read(buff); err != nil {
+		return nil, err
+	}
+
+	type_ := int(buff[0])
+
+	var o encoding.BinaryUnmarshaler
+
+	switch type_ {
+	case TypeHello:
+		o = &Hello{}
+	case TypeHandshake:
+		o = &Handshake{}
+	case TypeHandshakeResponse:
+		o = &HandshakeResponse{}
+	case TypeReadWrite:
+		o = &ReadWrite{}
+	case TypePing:
+		o = &Ping{}
+	case TypeEOF:
+		o = &EOF{}
+	}
+
+	buff = make([]byte, 2)
+
+	if _, err := ac.Conn.Read(buff); err != nil {
+		return nil, err
+	}
+
+	size := binary.LittleEndian.Uint16(buff)
+
+	buff = make([]byte, size)
+
+	if _, err := ac.Conn.Read(buff); err != nil {
+		return nil, err
+	}
+
+	if err := o.UnmarshalBinary(buff[:]); err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+func (ac conn2) send(o encoding.BinaryMarshaler) error {
+	// write type
+	switch o.(type) {
+	case Hello:
+		ac.Conn.Write([]byte{uint8(TypeHello)})
+	case Handshake:
+		ac.Conn.Write([]byte{uint8(TypeHandshake)})
+	case HandshakeResponse:
+		ac.Conn.Write([]byte{uint8(TypeHandshakeResponse)})
+	case Ping:
+		ac.Conn.Write([]byte{uint8(TypePing)})
+	case ReadWrite:
+		ac.Conn.Write([]byte{uint8(TypeReadWrite)})
+	case EOF:
+		ac.Conn.Write([]byte{uint8(TypeEOF)})
+	}
+
+	data, err := o.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	buff := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buff[0:2], uint16(len(data)))
+
+	if _, err := ac.Conn.Write(buff); err != nil {
+		return err
+	}
+
+	if _, err := ac.Conn.Write(data[:]); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/listener/agent/connection.go
+++ b/listener/agent/connection.go
@@ -31,6 +31,7 @@
 package agent
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -46,7 +47,7 @@ type agentConnection struct {
 
 	in chan []byte
 
-	out chan ReadWrite
+	out chan interface{}
 
 	m sync.Mutex
 }
@@ -64,6 +65,7 @@ func (dc *agentConnection) Read(b []byte) (int, error) {
 
 	data, ok := <-dc.in
 	if !ok {
+		fmt.Println("NOT OK, RETURN EOF")
 		return 0, io.EOF
 	}
 
@@ -109,12 +111,7 @@ func (dc *agentConnection) Close() error {
 		Raddr: dc.RemoteAddr(),
 	}
 
-	if data, err := p.MarshalBinary(); err == nil {
-		dc.in <- data
-	} else {
-		log.Error("Error marshaling hello: %s", err.Error())
-		return err
-	}
+	dc.out <- p
 
 	close(dc.in)
 

--- a/listener/agent/connection.go
+++ b/listener/agent/connection.go
@@ -1,0 +1,143 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package agent
+
+import (
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+type agentConnection struct {
+	Laddr net.Addr
+	Raddr net.Addr
+
+	buff   []byte
+	closed bool
+
+	in chan []byte
+
+	out chan ReadWrite
+
+	m sync.Mutex
+}
+
+func (dc *agentConnection) Read(b []byte) (int, error) {
+	if len(dc.buff) >= len(b) {
+		dc.m.Lock()
+		defer dc.m.Unlock()
+
+		n := copy(b[:], dc.buff[0:])
+		dc.buff = dc.buff[n:]
+
+		return n, nil
+	}
+
+	data, ok := <-dc.in
+	if !ok {
+		return 0, io.EOF
+	}
+
+	dc.m.Lock()
+	defer dc.m.Unlock()
+
+	dc.buff = append(dc.buff, data[:]...)
+
+	n := copy(b[:], dc.buff[0:])
+	dc.buff = dc.buff[n:]
+
+	return n, nil
+}
+
+func (dc *agentConnection) Write(b []byte) (int, error) {
+	dc.m.Lock()
+	defer dc.m.Unlock()
+
+	payload := make([]byte, len(b))
+
+	copy(payload, b)
+
+	p := ReadWrite{
+		Laddr:   dc.LocalAddr(),
+		Raddr:   dc.RemoteAddr(),
+		Payload: payload[:],
+	}
+
+	dc.out <- p
+	return len(b), nil
+}
+
+func (dc *agentConnection) Close() error {
+	dc.m.Lock()
+	defer dc.m.Unlock()
+
+	if dc.closed {
+		return nil
+	}
+
+	p := EOF{
+		Laddr: dc.LocalAddr(),
+		Raddr: dc.RemoteAddr(),
+	}
+
+	if data, err := p.MarshalBinary(); err == nil {
+		dc.in <- data
+	} else {
+		log.Error("Error marshaling hello: %s", err.Error())
+		return err
+	}
+
+	close(dc.in)
+
+	dc.closed = true
+	return nil
+}
+
+func (dc *agentConnection) LocalAddr() net.Addr {
+	return dc.Laddr
+}
+
+func (dc *agentConnection) RemoteAddr() net.Addr {
+	return dc.Raddr
+}
+
+func (dc *agentConnection) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (dc *agentConnection) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (dc *agentConnection) SetWriteDeadline(t time.Time) error {
+	return nil
+}

--- a/listener/agent/connections.go
+++ b/listener/agent/connections.go
@@ -36,6 +36,13 @@ import (
 
 type Connections []*agentConnection
 
+func (c *Connections) Add(ac *agentConnection) {
+	*c = append(*c, ac)
+}
+
+func (c *Connections) Delete(*agentConnection) {
+}
+
 func (c Connections) Get(laddr net.Addr, raddr net.Addr) *agentConnection {
 	for _, conn := range c {
 		if conn.Laddr.String() != laddr.String() {

--- a/listener/agent/connections.go
+++ b/listener/agent/connections.go
@@ -1,0 +1,53 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package agent
+
+import (
+	"net"
+)
+
+type Connections []*agentConnection
+
+func (c Connections) Get(laddr net.Addr, raddr net.Addr) *agentConnection {
+	for _, conn := range c {
+		if conn.Laddr.String() != laddr.String() {
+			continue
+		}
+
+		if conn.Raddr.String() != raddr.String() {
+			continue
+		}
+
+		return conn
+	}
+
+	return nil
+}

--- a/listener/agent/decoder.go
+++ b/listener/agent/decoder.go
@@ -1,0 +1,124 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package agent
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+)
+
+func NewDecoder(data []byte) *Decoder {
+	return &Decoder{
+		Buffer:    bytes.NewBuffer(data),
+		LastError: nil,
+	}
+}
+
+type Decoder struct {
+	*bytes.Buffer
+
+	LastError error
+}
+
+func (d *Decoder) ReadData() []byte {
+	if d.LastError != nil {
+		return []byte{}
+	}
+
+	l := d.ReadUint16()
+
+	buffer := make([]byte, l)
+	if _, err := d.Read(buffer[:]); err != nil {
+		d.LastError = err
+		return []byte{}
+	}
+
+	return buffer
+}
+
+func (d *Decoder) ReadString() string {
+	if d.LastError != nil {
+		return ""
+	}
+
+	l := d.ReadUint16()
+
+	buffer := make([]byte, l)
+	if _, err := d.Read(buffer[:]); err != nil {
+		d.LastError = err
+		return ""
+	}
+
+	return string(buffer)
+}
+
+func (d *Decoder) ReadUint16() int {
+	if d.LastError != nil {
+		return 0
+	}
+
+	buffer := [2]byte{}
+	if _, err := d.Read(buffer[:]); err != nil {
+		d.LastError = err
+		return 0
+	}
+
+	return int(binary.LittleEndian.Uint16(buffer[:]))
+}
+
+func (d *Decoder) ReadUint8() int {
+	if d.LastError != nil {
+		return 0
+	}
+
+	b, err := d.ReadByte()
+	if err != nil {
+		d.LastError = err
+	}
+
+	return int(b)
+}
+
+func (d *Decoder) ReadAddr() net.Addr {
+	if d.LastError != nil {
+		return nil
+	}
+
+	data := d.ReadData()
+	ip := net.IP(data)
+	port := d.ReadUint16()
+
+	return &net.TCPAddr{
+		IP:   ip,
+		Port: port,
+	}
+}

--- a/listener/agent/encoder.go
+++ b/listener/agent/encoder.go
@@ -1,0 +1,73 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package agent
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+)
+
+type Encoder struct {
+	bytes.Buffer
+}
+
+func (e *Encoder) WriteUint8(v int) {
+	e.WriteByte(uint8(v))
+}
+
+func (e *Encoder) WriteUint16(v int) {
+	b := [2]byte{}
+	binary.LittleEndian.PutUint16(b[:], uint16(v))
+	e.Write(b[:])
+}
+
+func (e *Encoder) WriteString(s string) {
+	e.WriteData([]byte(s))
+}
+
+func (e *Encoder) WriteData(data []byte) {
+	e.WriteUint16(len(data))
+	e.Write(data)
+}
+
+func (e *Encoder) WriteAddr(address net.Addr) {
+	var ip net.IP
+	var port int
+
+	if ta, ok := address.(*net.TCPAddr); ok {
+		ip = ta.IP
+		port = ta.Port
+	}
+
+	e.WriteData(ip)
+	e.WriteUint16(port)
+}

--- a/listener/agent/messages.go
+++ b/listener/agent/messages.go
@@ -1,0 +1,223 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package agent
+
+import (
+	"errors"
+	"net"
+)
+
+const (
+	TypeHello             int = 0x00
+	TypeReadWrite         int = 0x01
+	TypePing              int = 0x05
+	TypeEOF               int = 0x04
+	TypeHandshake         int = 0x02
+	TypeHandshakeResponse int = 0x03
+)
+
+type Handshake struct {
+}
+
+func (r *Handshake) UnmarshalBinary(data []byte) error {
+	d := NewDecoder(data)
+
+	if d.ReadUint8() != TypeHandshake {
+		return errors.New("Not a handshake packet")
+	}
+
+	return nil
+}
+
+func (h Handshake) MarshalBinary() ([]byte, error) {
+	e := Encoder{}
+	e.WriteUint8(TypeHandshake)
+	return e.Bytes(), nil
+}
+
+type HandshakeResponse struct {
+	Addresses []net.Addr
+}
+
+func (h *HandshakeResponse) UnmarshalBinary(data []byte) error {
+	d := NewDecoder(data)
+
+	if d.ReadUint8() != TypeHandshakeResponse {
+		return errors.New("Not a handshake packet")
+	}
+
+	n := d.ReadUint8()
+
+	h.Addresses = make([]net.Addr, n)
+
+	for i := 0; i < n; i++ {
+		h.Addresses[i] = d.ReadAddr()
+	}
+
+	return nil
+}
+
+func (h HandshakeResponse) MarshalBinary() ([]byte, error) {
+	e := Encoder{}
+	e.WriteUint8(TypeHandshakeResponse)
+	e.WriteUint8(len(h.Addresses))
+
+	for _, address := range h.Addresses {
+		e.WriteAddr(address)
+	}
+
+	return e.Bytes(), nil
+}
+
+type Hello struct {
+	Token string
+	Laddr net.Addr
+	Raddr net.Addr
+}
+
+func (h Hello) MarshalBinary() ([]byte, error) {
+	e := Encoder{}
+
+	e.WriteUint8(TypeHello)
+	e.WriteUint8(0)
+
+	e.WriteString(h.Token)
+
+	e.WriteAddr(h.Laddr)
+	e.WriteAddr(h.Raddr)
+
+	return e.Bytes(), nil
+}
+
+func (h *Hello) UnmarshalBinary(data []byte) error {
+	decoder := NewDecoder(data)
+
+	if decoder.ReadUint8() != TypeHello {
+		return errors.New("Not a hello packet")
+	}
+
+	_ = decoder.ReadUint8() /* protocol */
+
+	h.Token = decoder.ReadString()
+	h.Laddr = decoder.ReadAddr()
+	h.Raddr = decoder.ReadAddr()
+	return nil
+}
+
+type Ping struct {
+	Token string
+	Laddr net.Addr
+	Raddr net.Addr
+}
+
+func (h Ping) MarshalBinary() ([]byte, error) {
+	e := Encoder{}
+
+	e.WriteUint8(TypePing)
+	e.WriteUint8(0)
+
+	e.WriteString(h.Token)
+
+	e.WriteAddr(h.Laddr)
+	e.WriteAddr(h.Raddr)
+
+	return e.Bytes(), nil
+}
+
+type EOF struct {
+	Laddr net.Addr
+	Raddr net.Addr
+}
+
+func (r *EOF) UnmarshalBinary(data []byte) error {
+	decoder := NewDecoder(data)
+
+	if decoder.ReadUint8() != TypeEOF {
+		return errors.New("Not a eof packet")
+	}
+
+	decoder.ReadUint8()
+
+	r.Laddr = decoder.ReadAddr()
+	r.Raddr = decoder.ReadAddr()
+
+	return nil
+}
+
+func (h EOF) MarshalBinary() ([]byte, error) {
+	e := Encoder{}
+
+	e.WriteUint8(TypeEOF)
+	e.WriteUint8(0)
+
+	e.WriteAddr(h.Laddr)
+	e.WriteAddr(h.Raddr)
+
+	return e.Bytes(), nil
+}
+
+type ReadWrite struct {
+	Laddr net.Addr
+	Raddr net.Addr
+
+	Payload []byte
+}
+
+func (h ReadWrite) MarshalBinary() ([]byte, error) {
+	e := Encoder{}
+
+	e.WriteUint8(TypeReadWrite)
+	e.WriteUint8(0)
+
+	e.WriteAddr(h.Laddr)
+	e.WriteAddr(h.Raddr)
+
+	e.WriteData(h.Payload)
+
+	return e.Bytes(), nil
+}
+
+func (r *ReadWrite) UnmarshalBinary(data []byte) error {
+	decoder := NewDecoder(data)
+
+	if decoder.ReadUint8() != TypeReadWrite {
+		return errors.New("Not a read packet")
+	}
+
+	decoder.ReadUint8()
+
+	r.Laddr = decoder.ReadAddr()
+	r.Raddr = decoder.ReadAddr()
+
+	r.Payload = decoder.ReadData()
+
+	return nil
+}


### PR DESCRIPTION
The Honeytrap Agent tunnels traffic through to Honeytrap, allowing quick deployments of simple agents. 