### PR TITLE
honeytrap: Configurable data directory

### DIFF
--- a/cmd/honeytrap/main.go
+++ b/cmd/honeytrap/main.go
@@ -107,7 +107,7 @@ func serve(c *cli.Context) error {
 	}
 
 	if d := c.String("data"); d == "" {
-	} else if fn, err := server.WithHomeDir(d); err != nil {
+	} else if fn, err := server.WithDataDir(d); err != nil {
 		ec := cli.NewExitError(err.Error(), 1)
 		return ec
 	} else {

--- a/cmd/honeytrap/main.go
+++ b/cmd/honeytrap/main.go
@@ -96,9 +96,7 @@ type Cmd struct {
 }
 
 func serve(c *cli.Context) error {
-	options := []server.OptionFn{
-		server.WithToken(),
-	}
+	var options []server.OptionFn
 
 	if v := c.String("config"); v == "" {
 	} else if fn, err := server.WithConfig(v); err != nil {
@@ -115,6 +113,8 @@ func serve(c *cli.Context) error {
 	} else {
 		options = append(options, fn)
 	}
+
+	options = append(options, server.WithToken())
 
 	if c.GlobalBool("cpu-profile") {
 		options = append(options, server.WithCPUProfiler())

--- a/cmd/honeytrap/main.go
+++ b/cmd/honeytrap/main.go
@@ -78,7 +78,7 @@ var globalFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "data, d",
-		Value: ".honeytrap",
+		Value: "~/.honeytrap",
 		Usage: "Store data in `DIR`",
 	},
 	cli.BoolFlag{Name: "cpu-profile", Usage: "Enable cpu profiler"},

--- a/cmd/honeytrap/main.go
+++ b/cmd/honeytrap/main.go
@@ -76,6 +76,11 @@ var globalFlags = []cli.Flag{
 		Value: "config.toml",
 		Usage: "Load configuration from `FILE`",
 	},
+	cli.StringFlag{
+		Name:  "data, d",
+		Value: ".honeytrap",
+		Usage: "Store data in `DIR`",
+	},
 	cli.BoolFlag{Name: "cpu-profile", Usage: "Enable cpu profiler"},
 	cli.BoolFlag{Name: "mem-profile", Usage: "Enable memory profiler"},
 	cli.BoolFlag{Name: "profiler", Usage: "Enable web profiler"},
@@ -97,6 +102,14 @@ func serve(c *cli.Context) error {
 
 	if v := c.String("config"); v == "" {
 	} else if fn, err := server.WithConfig(v); err != nil {
+		ec := cli.NewExitError(err.Error(), 1)
+		return ec
+	} else {
+		options = append(options, fn)
+	}
+
+	if d := c.String("data"); d == "" {
+	} else if fn, err := server.WithHomeDir(d); err != nil {
 		ec := cli.NewExitError(err.Error(), 1)
 		return ec
 	} else {

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -99,7 +99,7 @@ type Honeytrap struct {
 
 	token string
 
-	homeDir string
+	dataDir string
 
 	matchers []*ServiceMap
 }

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -99,6 +99,8 @@ type Honeytrap struct {
 
 	token string
 
+	homeDir string
+
 	matchers []*ServiceMap
 }
 

--- a/server/options.go
+++ b/server/options.go
@@ -74,7 +74,7 @@ func WithConfig(s string) (OptionFn, error) {
 	}, nil
 }
 
-func WithHomeDir(s string) (OptionFn, error) {
+func WithDataDir(s string) (OptionFn, error) {
 	var err error
 	var usr *user.User
 	if usr, err = user.Current(); err != nil {
@@ -102,8 +102,8 @@ func WithHomeDir(s string) (OptionFn, error) {
 	}
 
 	return func(b *Honeytrap) error {
-		b.homeDir = p
-		storage.SetHomeDir(p)
+		b.dataDir = p
+		storage.SetDataDir(p)
 		return nil
 	}, nil
 }
@@ -113,7 +113,7 @@ func WithToken() OptionFn {
 
 	return func(h *Honeytrap) error {
 		h.token = uid
-		p := h.homeDir
+		p := h.dataDir
 		p = path.Join(p, "token")
 
 		if _, err := os.Stat(p); os.IsNotExist(err) {

--- a/server/options.go
+++ b/server/options.go
@@ -40,6 +40,7 @@ import (
 
 	_ "net/http/pprof"
 
+	"github.com/honeytrap/honeytrap/storage"
 	"github.com/pkg/profile"
 	"github.com/rs/xid"
 
@@ -102,6 +103,7 @@ func WithHomeDir(s string) (OptionFn, error) {
 
 	return func(b *Honeytrap) error {
 		b.homeDir = p
+		storage.SetHomeDir(p)
 		return nil
 	}, nil
 }

--- a/server/options.go
+++ b/server/options.go
@@ -36,6 +36,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 
 	_ "net/http/pprof"
 
@@ -79,7 +80,12 @@ func WithHomeDir(s string) (OptionFn, error) {
 		return nil, err
 	}
 
-	p := path.Join(usr.HomeDir, s)
+	var p string
+	if s == ".honeytrap" {
+		p = path.Join(usr.HomeDir, s)
+	} else {
+		p, err = filepath.Abs(s)
+	}
 
 	_, err = os.Stat(p)
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -32,9 +32,6 @@ package storage
 
 import (
 	"log"
-	"os"
-	"os/user"
-	"path"
 	"path/filepath"
 
 	"github.com/dgraph-io/badger"
@@ -45,38 +42,18 @@ type storage interface {
 	Set(string, []byte) error
 }
 
-var db = MustDB()
+var db *badger.DB
+var homeDir string
 
-func HomeDir() string {
-	var err error
-	var usr *user.User
-	if usr, err = user.Current(); err != nil {
-		panic(err)
-	}
-
-	p := path.Join(usr.HomeDir, ".honeytrap")
-
-	_, err = os.Stat(p)
-
-	switch {
-	case err == nil:
-		break
-	case os.IsNotExist(err):
-		if err = os.Mkdir(p, 0755); err != nil {
-			panic(err)
-		}
-	default:
-		panic(err)
-	}
-
-	return p
+func SetHomeDir(s string) {
+	homeDir = s
+	db = MustDB()
 }
 
 func MustDB() *badger.DB {
 	opts := badger.DefaultOptions
 
-	p := HomeDir()
-	p = filepath.Join(p, "badger.db")
+	p := filepath.Join(homeDir, "badger.db")
 
 	opts.Dir = p
 	opts.ValueDir = p

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -43,17 +43,17 @@ type storage interface {
 }
 
 var db *badger.DB
-var homeDir string
+var dataDir string
 
-func SetHomeDir(s string) {
-	homeDir = s
+func SetDataDir(s string) {
+	dataDir = s
 	db = MustDB()
 }
 
 func MustDB() *badger.DB {
 	opts := badger.DefaultOptions
 
-	p := filepath.Join(homeDir, "badger.db")
+	p := filepath.Join(dataDir, "badger.db")
 
 	opts.Dir = p
 	opts.ValueDir = p


### PR DESCRIPTION
This PR introduces configurable home dirs. 
Fixes #132 

It adds a CLI flag parameter `-data` or `-d` shorthand and sets that as homedir in the modified `HomeDir` -> `WithHomeDir` function. To allow the `WithToken()` function to use it as well, it's added as a field in the Honeytrap struct. All permission checks are kept intact.