### PR TITLE
Add read timeout to AgentConnection

### DIFF
--- a/listener/agent/connection.go
+++ b/listener/agent/connection.go
@@ -73,6 +73,11 @@ func (dc *agentConnection) Read(b []byte) (int, error) {
 		return n, nil
 	}
 
+	// Don't timeout when deadline is 0
+	if dc.readTimeout.IsZero() {
+		dc.readTimeout = time.Now().Add(24 * time.Hour)
+	}
+
 	select {
 	case <-time.After(time.Until(dc.readTimeout)):
 		return 0, &errorTimeout{}

--- a/listener/agent/error.go
+++ b/listener/agent/error.go
@@ -1,0 +1,43 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package agent
+
+type errorTimeout struct {
+}
+
+func (e *errorTimeout) Error() string {
+	return "i/o timeout"
+}
+func (e *errorTimeout) Timeout() bool {
+	return true
+}
+
+var ErrTimeout = &errorTimeout{}


### PR DESCRIPTION
This PR implements the `SetReadDeadline()` for the `agentConnection` struct. After the timeout, it will return a timeout error instead of waiting. If no timeout is set, the connection times out after 24 hours.