### PR TITLE
Lxc container housekeeper

### DIFF
--- a/director/lxc/lxc.go
+++ b/director/lxc/lxc.go
@@ -30,6 +30,38 @@
  */
 package lxc
 
-import logging "github.com/op/go-logging"
+import (
+	"time"
+
+	logging "github.com/op/go-logging"
+)
 
 var log = logging.MustGetLogger("director/lxc")
+
+type Delays struct {
+	FreezeDelay      Delay `toml:"freeze_every"`
+	StopDelay        Delay `toml:"stop_every"`
+	HousekeeperDelay Delay `toml:"housekeeper_every"`
+}
+
+// Delay defines a duration type.
+type Delay time.Duration
+
+// Duration returns the type of the giving duration from the provided pointer.
+func (t *Delay) Duration() time.Duration {
+	return time.Duration(*t)
+}
+
+// UnmarshalText handles unmarshalling duration values from the provided slice.
+func (t *Delay) UnmarshalText(text []byte) error {
+	s := string(text)
+
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		log.Errorf("Error parsing duration (%s): %s", s, err.Error())
+		return err
+	}
+
+	*t = Delay(d)
+	return nil
+}

--- a/director/lxc/lxcconnection.go
+++ b/director/lxc/lxcconnection.go
@@ -1,0 +1,36 @@
+package lxc
+
+import (
+	"net"
+	"time"
+)
+
+// lxcContainerConn defines a custom connection type which proxies the data
+// for the container.
+type lxcContainerConn struct {
+	net.Conn
+	container *lxcContainer
+}
+
+// Read reads the giving set of data from the container connection to the
+// byte slice.
+func (c lxcContainerConn) Read(b []byte) (n int, err error) {
+	c.container.stillActive()
+	return c.Conn.Read(b)
+}
+
+// Write writes the data into byte slice from the container.
+func (c lxcContainerConn) Write(b []byte) (n int, err error) {
+	c.container.stillActive()
+	return c.Conn.Write(b)
+}
+
+// stillActive returns an error if the containerr is not still active
+func (c *lxcContainer) stillActive() error {
+	if err := c.ensureStarted(); err != nil {
+		return err
+	}
+
+	c.idle = time.Now()
+	return nil
+}

--- a/director/lxc/lxcconnection.go
+++ b/director/lxc/lxcconnection.go
@@ -1,3 +1,5 @@
+// +build lxc
+
 package lxc
 
 import (

--- a/director/lxc/lxcconnection.go
+++ b/director/lxc/lxcconnection.go
@@ -1,6 +1,7 @@
 package lxc
 
 import (
+	"fmt"
 	"net"
 	"time"
 )
@@ -27,10 +28,15 @@ func (c lxcContainerConn) Write(b []byte) (n int, err error) {
 
 // stillActive returns an error if the containerr is not still active
 func (c *lxcContainer) stillActive() error {
-	if err := c.ensureStarted(); err != nil {
-		return err
+	if c.isStopped() {
+		return fmt.Errorf("lxccontainer not running %s", c.name)
 	}
-
+	if c.isFrozen() {
+		return c.unfreeze()
+	}
+	if !c.isRunning() {
+		return fmt.Errorf("lxccontainer in unknown state %s:%s", c.name, c.c.State())
+	}
 	c.idle = time.Now()
 	return nil
 }


### PR DESCRIPTION
This PR adds the housekeeper feature which was lost in a previous merge. 

It starts a goroutine for each container, checking the time it's been idle. When that's more than the set delay, it changes the container status. Idle time updates on every Read and Write to the container, which is possible due to the new wrapped containerconnection struct. 

When a container is stopped, the housekeeper function terminutes, but it's started when the director Dials a container, ensuring there's always a housekeeper running for each running container.

Fixes #129 