### PR TITLE
Pass context to Directors and shut containers down on close

### DIFF
--- a/director/director.go
+++ b/director/director.go
@@ -31,6 +31,7 @@
 package director
 
 import (
+	"context"
 	"net"
 
 	"github.com/BurntSushi/toml"
@@ -73,6 +74,10 @@ type SetChanneler interface {
 	SetChannel(pushers.Channel)
 }
 
+type SetContexter interface {
+	SetContext(context.Context)
+}
+
 func WithChannel(channel pushers.Channel) func(Director) error {
 	return func(d Director) error {
 		if sc, ok := d.(SetChanneler); ok {
@@ -86,5 +91,14 @@ func WithConfig(c toml.Primitive) func(Director) error {
 	return func(d Director) error {
 		err := toml.PrimitiveDecode(c, d)
 		return err
+	}
+}
+
+func WithContext(c context.Context) func(Director) error {
+	return func(d Director) error {
+		if sc, ok := d.(SetContexter); ok {
+			sc.SetContext(c)
+		}
+		return nil
 	}
 }

--- a/director/forward/forward.go
+++ b/director/forward/forward.go
@@ -31,6 +31,7 @@
 package forward
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -56,13 +57,18 @@ func New(options ...func(director.Director) error) (director.Director, error) {
 }
 
 type forwardDirector struct {
-	eb pushers.Channel
+	ctx context.Context
+	eb  pushers.Channel
 
 	Host string `toml:"host"`
 }
 
 func (d *forwardDirector) SetChannel(eb pushers.Channel) {
 	d.eb = eb
+}
+
+func (d *forwardDirector) SetContext(ctx context.Context) {
+	d.ctx = ctx
 }
 
 func (d *forwardDirector) Dial(conn net.Conn) (net.Conn, error) {

--- a/director/lxc/lxc_linux.go
+++ b/director/lxc/lxc_linux.go
@@ -177,11 +177,10 @@ func (c *lxcContainer) housekeeper(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Debugf("LxcContainer %s: shutting down container", c.name)
+			log.Debugf("LxcContainer %s: stopping", c.name)
 			c.c.Stop()
-		default:
-			time.Sleep(time.Duration(c.Delays.HousekeeperDelay))
-
+			return
+		case <-time.After(time.Duration(c.Delays.HousekeeperDelay)):
 			if c.isStopped() {
 				continue
 			}

--- a/director/lxc/lxc_linux.go
+++ b/director/lxc/lxc_linux.go
@@ -33,6 +33,7 @@
 package lxc
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -67,6 +68,7 @@ func New(options ...func(director.Director) error) (director.Director, error) {
 }
 
 type lxcDirector struct {
+	ctx      context.Context
 	template string
 	eb       pushers.Channel
 	cache    *syncmap.Map // map[string]*lxcContainer
@@ -74,6 +76,10 @@ type lxcDirector struct {
 
 func (d *lxcDirector) SetChannel(eb pushers.Channel) {
 	d.eb = eb
+}
+
+func (d *lxcDirector) SetContext(ctx context.Context) {
+	d.ctx = ctx
 }
 
 func (d *lxcDirector) Dial(conn net.Conn) (net.Conn, error) {
@@ -108,7 +114,7 @@ func (d *lxcDirector) Dial(conn net.Conn) (net.Conn, error) {
 	}
 
 	// Housekeeper only runs in Running containers, so start it always
-	go c.(*lxcContainer).housekeeper()
+	go c.(*lxcContainer).housekeeper(d.ctx)
 
 	if ta, ok := conn.LocalAddr().(*net.TCPAddr); ok {
 		connection, err := c.(*lxcContainer).Dial("tcp", ta.Port)
@@ -163,25 +169,31 @@ func (d *lxcDirector) newContainer(name string, template string) (*lxcContainer,
 
 // housekeeper handles the needed process of handling internal logic
 // in maintaining the provided lxc.Container.
-func (c *lxcContainer) housekeeper() {
+func (c *lxcContainer) housekeeper(ctx context.Context) {
 	// container lifetime function
 	log.Infof("Housekeeper (%s) started.", c.name)
 	defer log.Infof("Housekeeper (%s) stopped.", c.name)
 
 	for {
-		time.Sleep(time.Duration(c.Delays.HousekeeperDelay))
-
-		if c.isStopped() {
-			continue
-		}
-
-		if time.Since(c.idle) > time.Duration(c.Delays.StopDelay) && c.isFrozen() {
-			log.Debugf("LxcContainer %s: idle for %s, stopping container", c.name, time.Now().Sub(c.idle).String())
+		select {
+		case <-ctx.Done():
+			log.Debugf("LxcContainer %s: shutting down container", c.name)
 			c.c.Stop()
-			return
-		} else if time.Since(c.idle) > time.Duration(c.Delays.FreezeDelay) && c.isRunning() {
-			log.Debugf("LxcContainer %s: idle for %s, freezing container", c.name, time.Now().Sub(c.idle).String())
-			c.c.Freeze()
+		default:
+			time.Sleep(time.Duration(c.Delays.HousekeeperDelay))
+
+			if c.isStopped() {
+				continue
+			}
+
+			if time.Since(c.idle) > time.Duration(c.Delays.StopDelay) && c.isFrozen() {
+				log.Debugf("LxcContainer %s: idle for %s, stopping container", c.name, time.Now().Sub(c.idle).String())
+				c.c.Stop()
+				return
+			} else if time.Since(c.idle) > time.Duration(c.Delays.FreezeDelay) && c.isRunning() {
+				log.Debugf("LxcContainer %s: idle for %s, freezing container", c.name, time.Now().Sub(c.idle).String())
+				c.c.Freeze()
+			}
 		}
 	}
 }

--- a/director/qemu/qemu.go
+++ b/director/qemu/qemu.go
@@ -34,6 +34,7 @@
 package qemu
 
 import (
+	"context"
 	"errors"
 	"net"
 
@@ -58,11 +59,16 @@ func New(options ...func(director.Director) error) (director.Director, error) {
 }
 
 type qemuDirector struct {
-	eb pushers.Channel
+	ctx context.Context
+	eb  pushers.Channel
 }
 
 func (d *qemuDirector) SetChannel(eb pushers.Channel) {
 	d.eb = eb
+}
+
+func (d *qemuDirector) SetContext(ctx context.Context) {
+	d.ctx = ctx
 }
 
 func (d *qemuDirector) Dial(conn net.Conn) (net.Conn, error) {

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -463,6 +463,7 @@ func (hc *Honeytrap) Run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			log.Info("Stopping honeytrap")
+			time.Sleep(2 * time.Second)
 			return
 		case conn := <-incoming:
 			go hc.handle(conn)

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -324,6 +324,7 @@ func (hc *Honeytrap) Run(ctx context.Context) {
 		} else if d, err := directorFunc(
 			director.WithChannel(hc.bus),
 			director.WithConfig(s),
+			director.WithContext(ctx),
 		); err != nil {
 			log.Fatalf("Error initializing director %s(%s): %s", key, x.Type, err)
 		} else {

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -462,6 +462,7 @@ func (hc *Honeytrap) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			log.Info("Stopping honeytrap")
 			return
 		case conn := <-incoming:
 			go hc.handle(conn)


### PR DESCRIPTION
This PR passes context to the director, so they can take appropriate action when Honeytrap is shutting down. It adds a 2 second delay on Honeytrap.Run() return to give the routines some time to detect the context change.