### PR TITLE
storage: setup db only once

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -46,6 +46,10 @@ var db *badger.DB
 var dataDir string
 
 func SetDataDir(s string) {
+	if db != nil {
+		return
+	}
+
 	dataDir = s
 	db = MustDB()
 }


### PR DESCRIPTION
I use SetDataDir to initialize storage in test files. This change checks if db is initialized already and if so do nothing.
This is not a neccesary change but a precaution for accidentally setting this to another dir if it is already set.