### PR TITLE
ssh: fix ssh sample config

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -99,10 +99,9 @@ banner="Extra telnet deamon"
 
 [service.ssh-auth]
 type="ssh-auth"
-banner="OpenSSH_7.2p2 Ubuntu-4ubuntu2.1"
+#The banner string should be US ASCII, start with "SSH-2.0-" and should not include a newline.
+banner="SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.2"
 canary="false"
-username="test"
-password="test"
 
 [service.elasticsearch01]
 type="http"

--- a/services/ssh/auth.go
+++ b/services/ssh/auth.go
@@ -57,7 +57,7 @@ func SSHAuth(options ...services.ServicerFunc) services.Servicer {
 	banner := "SSH-2.0-OpenSSH_6.6.1p1 2020Ubuntu-2ubuntu2"
 
 	srvc := &sshAuthService{
-		key:    s.PrivateKey(),
+		Key:    s.PrivateKey(),
 		Banner: banner,
 	}
 
@@ -73,7 +73,7 @@ type sshAuthService struct {
 
 	Banner string `toml:"banner"`
 
-	key    *privateKey `toml:"private-key"`
+	Key    *privateKey `toml:"private-key"`
 	config ssh.ServerConfig
 }
 
@@ -114,7 +114,7 @@ func (s *sshAuthService) Handle(ctx context.Context, conn net.Conn) error {
 		},
 	}
 
-	config.AddHostKey(s.key)
+	config.AddHostKey(s.Key)
 
 	sconn, chans, reqs, err := ssh.NewServerConn(conn, &config)
 	if err == io.EOF {


### PR DESCRIPTION
The current sample config contains an invalid banner for ssh, resulting in a broken service. The Key field wasn't capitalized so that wasn't working either.

This PR fixes both issues, and should result in ssh-auth working out-of-the-box again

Fixes #171 