### PR TITLE
honeytrap: Buffered file writes

### DIFF
--- a/pushers/file/file.go
+++ b/pushers/file/file.go
@@ -198,17 +198,22 @@ func (f *FileBackend) syncLoop() {
 					continue writeSync
 				}
 
-				if _, err := io.Copy(f.dest, &buf); err != nil && err != io.EOF {
-					log.Errorf("Failed to copy data to File : %+q", err)
+				if buf.Len() < (500 * 1024) {
+					continue
 				}
-
-				if err := f.dest.Sync(); err != nil {
-					log.Errorf("Failed to sync Write to File : %+q", err)
-				}
-
-				// Reset the buffer for reuse.
-				buf.Reset()
+			case <-time.After(time.Second):
 			}
+
+			if _, err := io.Copy(f.dest, &buf); err != nil && err != io.EOF {
+				log.Errorf("Failed to copy data to File : %+q", err)
+			}
+
+			if err := f.dest.Sync(); err != nil {
+				log.Errorf("Failed to sync Write to File : %+q", err)
+			}
+
+			// Reset the buffer for reuse.
+			buf.Reset()
 		}
 	}
 }


### PR DESCRIPTION
Instead of writing to the logfile on every single request, this PR stores messages in a buffer. It writes them when the buffer (500KB) is full or after a second. This should greatly reduce the stress on the hdd in high load situations. 

Buffer size and timeout is up for discussion, not sure what good values are.

Fixes #164 