### PR TITLE
Add hints for loading directors

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -165,7 +165,8 @@ banner="test"
 # a container or vm managed by honeytrap or an other remote IP address. Each 
 # director must have a name and type defined. The director name should match the
 # director option in the proxy configuration. Available directors, with their
-# default configuration values, can be found in <......>
+# default configuration values, can be found in the folder "director"; they can
+# be enabled at compile time in honeytrap.go.
 
 [director.googledns]
 type="remote"

--- a/director/director.go
+++ b/director/director.go
@@ -60,6 +60,14 @@ func Get(key string) (func(...func(Director) error) (Director, error), bool) {
 	return d, false
 }
 
+func GetAvailableDirectorNames() []string {
+	var out []string
+	for key := range directors {
+		out = append(out, key)
+	}
+	return out
+}
+
 // Director defines an interface which exposes an interface to allow structures that
 // implement this interface allow us to control containers which they provide.
 type Director interface {


### PR DESCRIPTION
This PR adds some information for the user on how to load directors (in `config.toml`) and gives debug information on which directors can be used (in error logs).