### PR TITLE
Implement Redis protocol

### DIFF
--- a/services/redis/commands.go
+++ b/services/redis/commands.go
@@ -34,7 +34,7 @@ import (
 	"fmt"
 )
 
-type cmd func(*redisService, []string, string) (string, bool)
+type cmd func(*redisService, []interface{}) (string, bool)
 
 var mapCmds = map[string]cmd{
 	"info": (*redisService).infoCmd,
@@ -55,16 +55,21 @@ var mapInfoCmds = map[string]infoSection{
 	"keyspace":    (*redisService).infoKeyspaceMsg,
 }
 
-func (s *redisService) infoCmd(args []string, userCmd string) (string, bool) {
+func (s *redisService) infoCmd(args []interface{}) (string, bool) {
 	switch len(args) {
-	case 1:
+	case 0:
 		return fmt.Sprintf(lenMsg(), len(s.infoSectionsMsg()), s.infoSectionsMsg()), false
-	case 2:
-		if fn, ok := mapInfoCmds[args[1]]; ok {
+	case 1:
+		_word := args[0].(redisDatum)
+		word, success := _word.ToString()
+		if !success {
+			return "Expected string argument, got something else", false
+		}
+		if fn, ok := mapInfoCmds[word]; ok {
 			return fmt.Sprintf(lenMsg(), len(fn(s)), fn(s)), false
-		} else if args[1] == "default" {
+		} else if word == "default" {
 			return fmt.Sprintf(lenMsg(), len(s.infoSectionsMsg()), s.infoSectionsMsg()), false
-		} else if args[1] == "all" {
+		} else if word == "all" {
 			return fmt.Sprintf(lenMsg(), len(s.allSectionsMsg()), s.allSectionsMsg()), false
 		} else {
 			return fmt.Sprintf(lenMsg(), len(lineBreakMsg()), lineBreakMsg()), false

--- a/services/redis/messages.go
+++ b/services/redis/messages.go
@@ -207,7 +207,7 @@ func (s *redisService) infoKeyspaceMsg() string {
 }
 
 func lenMsg() string {
-	return "$%d\n%s\n"
+	return "$%d\r\n%s\r\n"
 }
 
 func lineBreakMsg() string {
@@ -217,8 +217,8 @@ func lineBreakMsg() string {
 func errorMsg(errType string) string {
 	switch errType {
 	case "syntax":
-		return "-ERR syntax error\n"
+		return "-ERR syntax error\r\n"
 	default:
-		return "-ERR unknown command '%s'\n"
+		return "-ERR unknown command '%s'\r\n"
 	}
 }

--- a/services/redis/redis_handler.go
+++ b/services/redis/redis_handler.go
@@ -35,24 +35,15 @@ import (
 	"strings"
 )
 
-func CleanCmd(cmd string) []string {
-	args := []string{}
-
-	for _, arg := range strings.Split(cmd, " ") {
-		if arg == "" {
-			continue
-		}
-		arg = strings.ToLower(arg)
-		args = append(args, arg)
-	}
-	return args
-}
-
-func (s *redisService) REDISHandler(cmd string) (string, bool) {
-	args := CleanCmd(cmd)
-	if fn, ok := mapCmds[args[0]]; ok {
-		return fn(s, args, cmd)
+/* args is an array of interface{} because it could be either a redisDatum or
+ * an elementary datatype (int, string, etc.)
+ */
+func (s *redisService) REDISHandler(command string, args []interface{}) (string, bool) {
+	// Convert the command to lowercase
+	command = strings.ToLower(command)
+	if fn, ok := mapCmds[command]; ok {
+		return fn(s, args)
 	} else {
-		return fmt.Sprintf(errorMsg("unknown"), cmd), false
+		return fmt.Sprintf(errorMsg("unknown"), command), false
 	}
 }


### PR DESCRIPTION
As mentioned in #201, the current Redis implementation is not compatible with Redis clients - it only implements the [inline commands](https://redis.io/topics/protocol#inline-commands), which (as far as I know) isn't widely used.

This PR implements the Redis protocol with a simple parser, but does not support the "inline commands". If needed, it can also be implemented.