### PR TITLE
Install ca certs so https request will work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG LDFLAGS=""
 RUN go build -tags="" -ldflags="$(go run scripts/gen-ldflags.go)" -o /go/bin/app github.com/honeytrap/honeytrap
 
 FROM debian
+RUN apt-get update && apt-get install -y ca-certificates
 COPY --from=builder /go/bin/app /honeytrap/honeytrap
 
 RUN mkdir /config /data


### PR DESCRIPTION
When trying to use the remote config feature from the docker image I got the following error:

```
$ docker run honeytrap/honeytrap --config https://google.com
Get https://google.com: x509: failed to load system roots and no roots provided
```

Seems it needs the CA certs installing. This PR fixes that:

```
andrew@andrew:~/git/honeytrap$ docker run x --config https://mysite.com/config
Honeytrap starting (bae25ufpasn000ea8020)...
Version: 2018-03-04T16:43:25Z (93661d278d0e)
16:46:49.292 honeytrap/server ▶ DEBU 001 Using datadir: /data
..
..
````