### PR TITLE
Storage namespace prefix fix

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -95,7 +95,7 @@ type badgeStorage struct {
 func (s *badgeStorage) Get(key string) ([]byte, error) {
 	val := []byte{}
 
-	k := append(s.ns, []byte(key))
+	k := append(s.ns, key...)
 
 	err := s.db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get(k)
@@ -116,7 +116,7 @@ func (s *badgeStorage) Get(key string) ([]byte, error) {
 }
 
 func (s *badgeStorage) Set(key string, data []byte) error {
-	k := append(s.ns, []byte(key))
+	k := append(s.ns, key...)
 
 	return s.db.Update(func(txn *badger.Txn) error {
 		err := txn.Set(k, data)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -46,6 +46,10 @@ var db *badger.DB
 var dataDir string
 
 func SetDataDir(s string) {
+	if db != nil {
+		return
+	}
+
 	dataDir = s
 	db = MustDB()
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -78,6 +78,8 @@ type Storage interface {
 func Namespace(namespace string) (*badgeStorage, error) {
 	prefix := make([]byte, len(namespace)+1)
 
+	_ = copy(prefix, namespace)
+
 	prefix[len(namespace)] = byte('.')
 
 	return &badgeStorage{

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -45,6 +45,7 @@ type storage interface {
 var db *badger.DB
 var dataDir string
 
+// SetDataDir
 func SetDataDir(s string) {
 	if db != nil {
 		return
@@ -54,6 +55,7 @@ func SetDataDir(s string) {
 	db = MustDB()
 }
 
+// MustDB
 func MustDB() *badger.DB {
 	opts := badger.DefaultOptions
 
@@ -74,11 +76,13 @@ func MustDB() *badger.DB {
 	return db
 }
 
+// Storage interface
 type Storage interface {
 	Get(key string) ([]byte, error)
 	Set(key string, data []byte) error
 }
 
+// Namespace sets the namespace prefix
 func Namespace(namespace string) (*badgeStorage, error) {
 	prefix := make([]byte, len(namespace)+1)
 


### PR DESCRIPTION
The key prefix for badger db was not set.
Now it is [prefix].[key]