### PR TITLE
Fix unable to write logfile on 32 bits devices

### DIFF
--- a/config/utils.go
+++ b/config/utils.go
@@ -36,16 +36,16 @@ import (
 )
 
 //ConvertToInt wraps the internal int coverter
-func ConvertToInt(target string, def int) int {
+func ConvertToInt(target string, def uint64) int {
 	fo, err := strconv.Atoi(target)
 	if err != nil {
-		return def
+		return int(def)
 	}
 	return fo
 }
 
 // MakeDuration should become internal functions , config should return time.Duration
-func MakeDuration(target string, def int) time.Duration {
+func MakeDuration(target string, def uint64) time.Duration {
 	if !elapso.MatchString(target) {
 		return time.Duration(def)
 	}

--- a/config/utils.go
+++ b/config/utils.go
@@ -35,16 +35,16 @@ import (
 	"time"
 )
 
-//ConvertToInt wraps the internal int coverter
-func ConvertToInt(target string, def uint64) int {
+//ConvertToUint64 wraps the internal int converter
+func ConvertToUint64(target string, def uint64) uint64 {
 	fo, err := strconv.Atoi(target)
 	if err != nil {
-		return int(def)
+		return def
 	}
-	return fo
+	return uint64(fo)
 }
 
-// MakeDuration should become internal functions , config should return time.Duration
+// MakeDuration should become internal functions, config should return time.Duration
 func MakeDuration(target string, def uint64) time.Duration {
 	if !elapso.MatchString(target) {
 		return time.Duration(def)
@@ -62,7 +62,7 @@ func MakeDuration(target string, def uint64) time.Duration {
 		return time.Duration(def)
 	}
 
-	dur := time.Duration(ConvertToInt(match[1], def))
+	dur := time.Duration(ConvertToUint64(match[1], def))
 
 	mtype := match[2]
 

--- a/config/utils.go
+++ b/config/utils.go
@@ -35,8 +35,8 @@ import (
 	"time"
 )
 
-//ConvertToUint64 wraps the internal int converter
-func ConvertToUint64(target string, def uint64) uint64 {
+//convertToUint64 wraps the internal int converter
+func convertToUint64(target string, def uint64) uint64 {
 	fo, err := strconv.Atoi(target)
 	if err != nil {
 		return def
@@ -62,7 +62,7 @@ func MakeDuration(target string, def uint64) time.Duration {
 		return time.Duration(def)
 	}
 
-	dur := time.Duration(ConvertToUint64(match[1], def))
+	dur := time.Duration(convertToUint64(match[1], def))
 
 	mtype := match[2]
 

--- a/pushers/file/file.go
+++ b/pushers/file/file.go
@@ -82,7 +82,7 @@ func New(options ...func(pushers.Channel) error) (pushers.Channel, error) {
 		fc.File = filepath.Join(pwd, fc.File)
 	}
 
-	fc.timeout = config.MakeDuration(fc.Timeout, int(defaultWaitTime))
+	fc.timeout = config.MakeDuration(fc.Timeout, uint64(defaultWaitTime))
 
 	return &fc, nil
 }


### PR DESCRIPTION
The `honeytrap.log` file was not being written on my PI 2 model B at all. After some searching, it became clear that it was an issue with the types, since the issue does not occur on a 64 bits machine.

The `defaultWaitTime` was being cast to an `int` value. This type, according to the docs, is [at least an int32](https://golang.org/pkg/builtin/#int). The value in the `defaultWaitTime` is defined as `5 * time.Second`, which is bigger than the max value of the `int32`.