### PR TITLE
[wip] services: redis: supporting different versions of redis

### DIFF
--- a/services/redis/messages.go
+++ b/services/redis/messages.go
@@ -32,178 +32,97 @@ package redis
 
 import (
 	"fmt"
+	"strings"
 )
 
 func (s *redisService) sectionsMsg() string {
-	return s.infoServerMsg() + s.infoClientsMsg() + s.infoMemoryMsg() + s.infoPersistenceMsg() + s.infoStatsMsg() + s.infoReplicationMsg() + s.infoCPUMsg() + s.infoClusterMsg()
+	return s.infoServerMsg() + "\r\n" + s.infoClientsMsg() + "\r\n" + s.infoMemoryMsg() + "\r\n" + s.infoPersistenceMsg() + "\r\n" + s.infoStatsMsg() + "\r\n" + s.infoReplicationMsg() + "\r\n" + s.infoCPUMsg() + "\r\n" + s.infoClusterMsg()
 }
 
 func (s *redisService) infoSectionsMsg() string {
-	return s.sectionsMsg() + s.infoKeyspaceMsg()
+	return s.sectionsMsg() + "\r\n" + s.infoKeyspaceMsg()
 }
 
 func (s *redisService) allSectionsMsg() string {
-	return s.sectionsMsg() + s.infoCommandstatsMsg() + s.infoKeyspaceMsg()
+	return s.sectionsMsg() + "\r\n" + s.infoCommandstatsMsg() + "\r\n" + s.infoKeyspaceMsg()
+}
+
+var msgs = map[string]string{}
+
+func init() {
+
+	msgs["ServerVersion"] = "# Server\r\n"
+	msgs["ClientsVersion"] = "# Clients\r\n"
+	msgs["MemoryVersion"] = "# Memory\r\n"
+	msgs["PersistenceVersion"] = "# Persistence\r\n"
+	msgs["StatsVersion"] = "# Stats\r\n"
+	msgs["ReplicationVersion"] = "# Replication\r\n"
+	msgs["CpuVersion"] = "# CPU\r\n"
+	msgs["CommandStatsVersion"] = "# Commandstats\r\n"
+	msgs["ClusterVersion"] = "# Cluster\r\n"
+	msgs["KeyspaceVersion"] = "# Keyspace\r\n"
+	msgs["ConnectedClientsVersion"] = "# Connected Clients\r\n"
+}
+
+func createMsg(section string) string {
+
+	msg := msgs[section]
+	RedisdefSection := Redisdef.FieldByName(section)
+
+	for y := 0; y < RedisdefSection.NumField(); y++ {
+
+		field := strings.ToLower(RedisdefSection.Type().Field(y).Name)
+		value := RedisdefSection.Field(y).Interface().(string)
+
+		if value != "__" {
+			msg += fmt.Sprintf("%s:%s\r\n", field, value)
+		}
+	}
+	return msg
 }
 
 func (s *redisService) infoServerMsg() string {
-	return fmt.Sprintf(`# Server
-redis_version:%s
-redis_git_sha1:00000000
-redis_git_dirty:0
-redis_build_id:f1060845dd32471a
-redis_mode:standalone
-os:%s
-arch_bits:64
-multiplexing_api:epoll
-atomicvar_api:atomic-builtin
-gcc_version:4.9.2
-process_id:1
-run_id:15444ca686daa4cfcf621e65a7aed097110bb598
-tcp_port:6379
-uptime_in_seconds:10396
-uptime_in_days:0
-hz:10
-lru_clock:5820570
-executable:/data/redis-server
-config_file:
-
-`, s.Version, s.Os)
+	return createMsg("ServerVersion")
 }
 
 func (s *redisService) infoClientsMsg() string {
-	return `# Clients
-connected_clients:0
-client_longest_output_list:0
-client_biggest_input_buf:0
-blocked_clients:0
-
-`
+	return createMsg("ClientsVersion")
 }
 
 func (s *redisService) infoMemoryMsg() string {
-	return `# Memory
-used_memory:1828264
-used_memory_human:808.85K
-used_memory_rss:4120576
-used_memory_rss_human:3.93M
-used_memory_peak:828264
-used_memory_peak_human:808.85K
-used_memory_peak_perc:100.00%
-used_memory_overhead:815150
-used_memory_startup:765520
-used_memory_dataset:13114
-used_memory_dataset_perc:20.90%
-total_system_memory:2096160768
-total_system_memory_human:1.95G
-used_memory_lua:37888
-used_memory_lua_human:37.00K
-maxmemory:0
-maxmemory_human:0B
-maxmemory_policy:noeviction
-mem_fragmentation_ratio:4.97
-mem_allocator:jemalloc-4.0.3
-active_defrag_running:0
-lazyfree_pending_objects:0
-
-`
+	return createMsg("MemoryVersion")
 }
 
 func (s *redisService) infoPersistenceMsg() string {
-	return `# Persistence
-loading:0
-rdb_changes_since_last_save:0
-rdb_bgsave_in_progress:0
-rdb_last_save_time:1515759614
-rdb_last_bgsave_status:ok
-rdb_last_bgsave_time_sec:-1
-rdb_current_bgsave_time_sec:-1
-rdb_last_cow_size:0
-aof_enabled:0
-aof_rewrite_in_progress:0
-aof_rewrite_scheduled:0
-aof_last_rewrite_time_sec:-1
-aof_current_rewrite_time_sec:-1
-aof_last_bgrewrite_status:ok
-aof_last_write_status:ok
-aof_last_cow_size:0
-
-`
+	return createMsg("PersistenceVersion")
 }
 
 func (s *redisService) infoStatsMsg() string {
-	return `total_connections_received:2
-total_commands_processed:1
-instantaneous_ops_per_sec:0
-total_net_input_bytes:14
-total_net_output_bytes:2664
-instantaneous_input_kbps:0.00
-instantaneous_output_kbps:0.00
-rejected_connections:0
-sync_full:0
-sync_partial_ok:0
-sync_partial_err:0
-expired_keys:0
-evicted_keys:0
-keyspace_hits:0
-keyspace_misses:0
-pubsub_channels:0
-pubsub_patterns:0
-latest_fork_usec:0
-migrate_cached_sockets:0
-slave_expires_tracked_keys:0
-active_defrag_hits:0
-active_defrag_misses:0
-active_defrag_key_hits:0
-active_defrag_key_misses:0
-
-`
+	return createMsg("StatsVersion")
 }
 
 func (s *redisService) infoReplicationMsg() string {
-	return `# Replication
-role:master
-connected_slaves:0
-master_replid:29e814284ae0619c1b2c09175f4b5b6a5aafff48
-master_replid2:0000000000000000000000000000000000000000
-master_repl_offset:0
-second_repl_offset:-1
-repl_backlog_active:0
-repl_backlog_size:1048576
-repl_backlog_first_byte_offset:0
-repl_backlog_histlen:0
-
-`
+	return createMsg("ReplicationVersion")
 }
 
 func (s *redisService) infoCPUMsg() string {
-	return `# CPU
-used_cpu_sys:20.83
-used_cpu_user:3.02
-used_cpu_sys_children:0.00
-used_cpu_user_children:0.00
-
-`
+	return createMsg("CpuVersion")
 }
 
 func (s *redisService) infoCommandstatsMsg() string {
-	return `# Commandstats
-cmdstat_info:calls=3,usec=181,usec_per_call=60.33
-
-`
+	return createMsg("CommandStatsVersion")
 }
 
 func (s *redisService) infoClusterMsg() string {
-	return `# Cluster
-cluster_enabled:0
-
-`
+	return createMsg("ClusterVersion")
 }
 
 func (s *redisService) infoKeyspaceMsg() string {
-	return `# Keyspace
+	return createMsg("KeyspaceVersion")
+}
 
-`
+func (s *redisService) infoConnectedClientsMsg() string {
+	return createMsg("ConnectedClientsVersion")
 }
 
 func lenMsg() string {

--- a/services/redis/redis.go
+++ b/services/redis/redis.go
@@ -51,26 +51,28 @@ var (
 )
 
 func REDIS(options ...services.ServicerFunc) services.Servicer {
+
 	s := &redisService{
-		redisServiceConfig: redisServiceConfig{
-			Version: "4.0.6",
-			Os:      "Linux 4.9.49-moby x86_64",
-		},
+		RedisServiceConfig: RedisServiceConfiguration{},
 	}
+
 	for _, o := range options {
 		o(s)
 	}
+
+	s.RedisServiceConfig, errList = s.configureRedisService()
+
+	if len(errList) != 0 {
+		for field, reason := range errList {
+			log.Errorf("Could not add [%s]: %s", field, reason)
+		}
+	}
+
 	return s
 }
 
-type redisServiceConfig struct {
-	Version string `toml:"version"`
-
-	Os string `toml:"os"`
-}
-
 type redisService struct {
-	redisServiceConfig
+	RedisServiceConfig RedisServiceConfiguration `toml:"config"`
 
 	ch pushers.Channel
 }

--- a/services/redis/redis_config.go
+++ b/services/redis/redis_config.go
@@ -1,0 +1,140 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package redis
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+var Redisdef = reflect.ValueOf(&RedisDefault).Elem()
+var errList = map[string]string{}
+
+func cleanVersion(v string) []int {
+	n := strings.Split(v, ".")
+	a := []int{}
+
+	for _, m := range n {
+		i, _ := strconv.Atoi(m)
+		a = append(a, i)
+	}
+	return a
+}
+
+func compareVersions(persoV, defaultV []int) bool {
+	for i := 0; i < len(defaultV); i++ {
+		if persoV[i] > defaultV[i] {
+			return true
+			break
+		} else if persoV[i] < defaultV[i] {
+			return false
+			break
+		}
+	}
+	return true
+}
+
+func splitDefault(totalvalue string) []string {
+	return strings.Split(totalvalue, ";")
+}
+
+func takePersoVersion(w string) []int {
+
+	dfltV := splitDefault(RedisDefault.ServerVersion.Redis_version)[2]
+	redisDefVersion := Redisdef.Field(0).Field(0)
+	if w != "" {
+		if checkRegexFn("U", "Redis_version", w) {
+			redisDefVersion.SetString(w)
+			return cleanVersion(w)
+		} else {
+			errList["Redis version"] = " Regex invalid "
+			redisDefVersion.SetString(dfltV)
+			return cleanVersion(dfltV)
+		}
+	} else {
+		Redisdef.Field(0).Field(0).SetString(dfltV)
+		return cleanVersion(dfltV)
+	}
+}
+
+func (s *redisService) configureRedisService() (RedisServiceConfiguration, map[string]string) {
+
+	redis_config_perso := s.RedisServiceConfig
+
+	redisperso := reflect.ValueOf(redis_config_perso)
+
+	redis_version_perso := takePersoVersion(redis_config_perso.Redis_version)
+
+	for i := 0; i < Redisdef.NumField(); i++ {
+		f := Redisdef.Field(i)
+
+		for j := 0; j < f.NumField(); j++ {
+
+			if i == 0 && j == 0 {
+				continue // skip the Redis_version field
+			}
+
+			z := f.Field(j)
+			field := Redisdef.Field(i).Type().Field(j).Name
+
+			defaultVersion := cleanVersion(splitDefault(z.Interface().(string))[0])
+			tt := Redisdef.Field(i).Field(j)
+			v := redisperso.Field(i).Field(j).Interface().(string)
+
+			defaultRegex := splitDefault(string(tt.Interface().(string)))[1]
+
+			defaultValue := splitDefault(string(tt.Interface().(string)))[2]
+
+			if compareVersions(redis_version_perso, defaultVersion) {
+				if v != "" {
+					if checkRegexFn(defaultRegex, field, v) { // add also redis_version_perso
+						tt.SetString(v)
+					} else {
+						errList[field] = " Regex invalid "
+						tt.SetString(defaultValue)
+					}
+
+				} else {
+					tt.SetString(defaultValue)
+
+				}
+			} else {
+				if v != "" {
+					errList[field] = fmt.Sprintf("Redis version %v doesn't implement this field", redis_version_perso)
+				}
+				tt.SetString("__")
+			}
+		}
+	}
+	return RedisDefault, errList
+}

--- a/services/redis/regex.go
+++ b/services/redis/regex.go
@@ -1,0 +1,69 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+
+package redis
+
+import (
+	"regexp"
+)
+
+var patterns = map[string]string{}
+
+func init() {
+	patterns["Redis_version"] = "(^[1-4]\\.[0-9](\\.[0-9]{1,2})?$)"
+	//...
+}
+
+func checkRegexFn(defaultRegex, field, value string) bool {
+
+	if defaultRegex == "U" {
+		regex_pattern := patterns[field]
+		r, _ := regexp.Compile(regex_pattern)
+
+		if r.MatchString(value) {
+			return true
+		} else {
+			return false
+			/*
+				switch defaultRegex {
+				case "TBD":
+					TBD(field, redis_version_perso)
+				case "CR":
+					CR(field, redis_version_perso)
+				case "R":
+					R(field, redis_verison_perso)
+				}
+			*/
+		}
+	} else {
+		return true
+	}
+}

--- a/services/redis/template.go
+++ b/services/redis/template.go
@@ -1,0 +1,303 @@
+/*
+* Honeytrap
+* Copyright (C) 2016-2017 DutchSec (https://dutchsec.com/)
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU Affero General Public License version 3 as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+* details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* version 3 along with this program in the file "LICENSE".  If not, see
+* <http://www.gnu.org/licenses/agpl-3.0.txt>.
+*
+* See https://honeytrap.io/ for more details. All requests should be sent to
+* licensing@honeytrap.io
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License version 3.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+* these Appropriate Legal Notices must retain the display of the "Powered by
+* Honeytrap" logo and retain the original copyright notice. If the display of the
+* logo is not reasonably feasible for technical reasons, the Appropriate Legal Notices
+* must display the words "Powered by Honeytrap" and retain the original copyright notice.
+ */
+package redis
+
+type RedisServiceConfiguration struct {
+	ServerVersion
+	ClientsVersion
+	MemoryVersion
+	PersistenceVersion
+	StatsVersion
+	ReplicationVersion
+	CpuVersion
+	CommandStatsVersion
+	ClusterVersion
+	KeyspaceVersion
+	ConnectedClientsVersion
+}
+
+type ServerVersion struct {
+	Redis_version     string
+	Redis_git_sha1    string
+	Redis_git_dirty   string
+	Redis_build_id    string
+	Redis_mode        string
+	Os                string
+	Arch_bits         string
+	Multiplexing_api  string
+	Atomicvar_api     string
+	Gcc_version       string
+	Process_id        string
+	Run_id            string
+	Tcp_port          string
+	Uptime_in_seconds string
+	Uptime_in_days    string
+	Hz                string
+	Lru_clock         string
+	Executable        string
+	Config_file       string
+}
+
+type ClientsVersion struct {
+	Connected_clients          string
+	Client_longest_output_list string
+	Client_biggest_input_buf   string
+	Blocked_clients            string
+}
+
+type MemoryVersion struct {
+	Used_memory               string
+	Used_memory_human         string
+	Used_memory_rss           string
+	Used_memory_rss_human     string
+	Used_memory_peak          string
+	Used_memory_peak_human    string
+	Used_memory_peak_perc     string
+	Used_memory_overhead      string
+	Used_memory_startup       string
+	Used_memory_dataset       string
+	Used_memory_dataset_perc  string
+	Total_system_memory       string
+	Total_system_memory_human string
+	Used_memory_lua           string
+	Used_memory_lua_human     string
+	Maxmemory                 string
+	Maxmemory_human           string
+	Maxmemory_policy          string
+	Mem_fragmentation_ratio   string
+	Mem_allocator             string
+	Active_defrag_running     string
+	Lazyfree_pending_objects  string
+}
+
+type PersistenceVersion struct {
+	Loading                      string
+	Rdb_changes_since_last_save  string
+	Rdb_bgsave_in_progress       string
+	Rdb_last_save_time           string
+	Rdb_last_bgsave_status       string
+	Rdb_last_bgsave_time_sec     string
+	Rdb_current_bgsave_time_sec  string
+	Rdb_last_cow_size            string
+	Aof_enabled                  string
+	Aof_rewrite_in_progress      string
+	Aof_rewrite_scheduled        string
+	Aof_last_rewrite_time_sec    string
+	Aof_current_rewrite_time_sec string
+	Aof_last_bgrewrite_status    string
+	Aof_last_write_status        string
+	Aof_last_cow_size            string
+}
+
+type StatsVersion struct {
+	Total_connections_received string
+	Total_commands_processed   string
+	Instantaneous_ops_per_sec  string
+	Total_net_input_bytes      string
+	Total_net_output_bytes     string
+	Instantaneous_input_kbps   string
+	Instantaneous_output_kbps  string
+	Rejected_connections       string
+	Sync_full                  string
+	Sync_partial_ok            string
+	Sync_partial_err           string
+	Expired_keys               string
+	Evicted_keys               string
+	Keyspace_hits              string
+	Keyspace_misses            string
+	Pubsub_channels            string
+	Pubsub_patterns            string
+	Latest_fork_usec           string
+	Migrate_cached_sockets     string
+	Slave_expires_tracked_keys string
+	Active_defrag_hits         string
+	Active_defrag_misses       string
+	Active_defrag_key_hits     string
+	Active_defrag_key_misses   string
+}
+
+type ReplicationVersion struct {
+	Role                           string
+	Connected_slaves               string
+	Master_replid                  string
+	Master_replid2                 string
+	Master_repl_offset             string
+	Second_repl_offset             string
+	Repl_backlog_active            string
+	Repl_backlog_size              string
+	Repl_backlog_first_byte_offset string
+	Repl_backlog_histlen           string
+}
+
+type CpuVersion struct {
+	Used_cpu_sys           string
+	Used_cpu_user          string
+	Used_cpu_sys_children  string
+	Used_cpu_user_children string
+}
+
+type CommandStatsVersion struct {
+	Cmdstat_info string
+}
+
+type ClusterVersion struct {
+	Cluster_enabled string
+}
+
+type KeyspaceVersion struct {
+}
+
+type ConnectedClientsVersion struct {
+}
+
+var RedisDefault = RedisServiceConfiguration{
+	ServerVersion: ServerVersion{
+		Redis_version:     "1.0.0;U;4.0.8",
+		Redis_git_sha1:    "1.0.0;TBD;00000000",
+		Redis_git_dirty:   "1.0.0;TBD;0",
+		Redis_build_id:    "1.0.0;TBD;f1060845dd32471a",
+		Redis_mode:        "1.0.0;TBD;standalone",
+		Os:                "1.0.0;TBD;Linux 4.9.49-moby x86_64",
+		Arch_bits:         "1.0.0;TBD;64",
+		Multiplexing_api:  "1.0.0;TBD;epoll",
+		Atomicvar_api:     "1.0.0;TBD;atomic-builtin",
+		Gcc_version:       "1.0.0;TBD;4.9.2",
+		Process_id:        "1.0.0;TBD;1",
+		Run_id:            "1.0.0;TBD;15444ca686daa4cfcf621e65a7aed097110bb598",
+		Tcp_port:          "1.0.0;TBD;6379",
+		Uptime_in_seconds: "1.0.0;TBD;10396",
+		Uptime_in_days:    "1.0.0;TBD;0",
+		Hz:                "1.0.0;TBD;10",
+		Lru_clock:         "1.0.0;TBD;8584119",
+		Executable:        "1.0.0;TBD;/data/redis-server",
+		Config_file:       "1.0.0;TBD;",
+	},
+	ClientsVersion: ClientsVersion{
+		Connected_clients:          "3.0.0;TBD;0",
+		Client_longest_output_list: "1.0.0;TBD;0",
+		Client_biggest_input_buf:   "1.0.0;TBD;0",
+		Blocked_clients:            "2.4.0;TBD;0",
+	},
+	MemoryVersion: MemoryVersion{
+		Used_memory:               "1.0.0;TBD;1828264",
+		Used_memory_human:         "1.0.0;TBD;808.85K",
+		Used_memory_rss:           "1.0.0;TBD;4120576",
+		Used_memory_rss_human:     "3.2.8;TBD;3.93M",
+		Used_memory_peak:          "1.0.0;TBD;828264",
+		Used_memory_peak_human:    "1.0.0;TBD;808.85K",
+		Used_memory_peak_perc:     "3.9.103;TBD;100.00%",
+		Used_memory_overhead:      "3.9.103;TBD;815150",
+		Used_memory_startup:       "3.9.103;TBD;765520",
+		Used_memory_dataset:       "3.9.103;TBD;13114",
+		Used_memory_dataset_perc:  "3.9.103;TBD;20.90%",
+		Total_system_memory:       "3.2.8;TBD;2096160768",
+		Total_system_memory_human: "3.2.8;TBD;1.95G",
+		Used_memory_lua:           "1.0.0;TBD;37888",
+		Used_memory_lua_human:     "3.2.8;TBD;37.00K",
+		Maxmemory:                 "3.2.8;TBD;0",
+		Maxmemory_human:           "3.2.8;TBD;0B",
+		Maxmemory_policy:          "3.2.8;TBD;noeviction",
+		Mem_fragmentation_ratio:   "1.0.0;TBD;4.97",
+		Mem_allocator:             "1.0.0;TBD;jemalloc-4.0.3",
+		Active_defrag_running:     "3.9.103;TBD;0",
+		Lazyfree_pending_objects:  "3.9.103;TBD;0",
+	},
+	PersistenceVersion: PersistenceVersion{
+		Loading:                      "1.0.0;TBD;0",
+		Rdb_changes_since_last_save:  "1.0.0;TBD;0",
+		Rdb_bgsave_in_progress:       "1.0.0;TBD;0",
+		Rdb_last_save_time:           "1.0.0;TBD;1515759614",
+		Rdb_last_bgsave_status:       "1.0.0;TBD;ok",
+		Rdb_last_bgsave_time_sec:     "1.0.0;TBD;-1",
+		Rdb_current_bgsave_time_sec:  "1.0.0;TBD;-1",
+		Rdb_last_cow_size:            "1.0.0;TBD;0",
+		Aof_enabled:                  "1.0.0;TBD;0",
+		Aof_rewrite_in_progress:      "1.0.0;TBD;0",
+		Aof_rewrite_scheduled:        "1.0.0;TBD;0",
+		Aof_last_rewrite_time_sec:    "1.0.0;TBD;-1",
+		Aof_current_rewrite_time_sec: "1.0.0;TBD;-1",
+		Aof_last_bgrewrite_status:    "1.0.0;TBD;ok",
+		Aof_last_write_status:        "1.0.0;TBD;ok",
+		Aof_last_cow_size:            "1.0.0;TBD;0",
+	},
+	StatsVersion: StatsVersion{
+		Total_connections_received: "1.0.0;TBD;2",
+		Total_commands_processed:   "1.0.0;TBD;1",
+		Instantaneous_ops_per_sec:  "1.0.0;TBD;0",
+		Total_net_input_bytes:      "1.0.0;TBD;14",
+		Total_net_output_bytes:     "1.0.0;TBD;2664",
+		Instantaneous_input_kbps:   "1.0.0;TBD;0.00",
+		Instantaneous_output_kbps:  "1.0.0;TBD;0.00",
+		Rejected_connections:       "1.0.0;TBD;0",
+		Sync_full:                  "1.0.0;TBD;0",
+		Sync_partial_ok:            "1.0.0;TBD;0",
+		Sync_partial_err:           "1.0.0;TBD;0",
+		Expired_keys:               "1.0.0;TBD;0",
+		Evicted_keys:               "1.0.0;TBD;0",
+		Keyspace_hits:              "1.0.0;TBD;0",
+		Keyspace_misses:            "1.0.0;TBD;0",
+		Pubsub_channels:            "1.0.0;TBD;0",
+		Pubsub_patterns:            "1.0.0;TBD;0",
+		Latest_fork_usec:           "1.0.0;TBD;0",
+		Migrate_cached_sockets:     "1.0.0;TBD;0",
+		Slave_expires_tracked_keys: "1.0.0;TBD;0",
+		Active_defrag_hits:         "1.0.0;TBD;0",
+		Active_defrag_misses:       "1.0.0;TBD;0",
+		Active_defrag_key_hits:     "1.0.0;TBD;0",
+		Active_defrag_key_misses:   "1.0.0;TBD;0",
+	},
+	ReplicationVersion: ReplicationVersion{
+		Role:                           "1.0.0;TBD;master",
+		Connected_slaves:               "1.0.0;TBD;0",
+		Master_replid:                  "1.0.0;TBD;29e814284ae0619c1b2c09175f4b5b6a5aafff48",
+		Master_replid2:                 "1.0.0;TBD;0000000000000000000000000000000000000000",
+		Master_repl_offset:             "1.0.0;TBD;0",
+		Second_repl_offset:             "1.0.0;TBD;-1",
+		Repl_backlog_active:            "1.0.0;TBD;0",
+		Repl_backlog_size:              "1.0.0;TBD;1048576",
+		Repl_backlog_first_byte_offset: "1.0.0;TBD;0",
+		Repl_backlog_histlen:           "1.0.0;TBD;0",
+	},
+	CpuVersion: CpuVersion{
+		Used_cpu_sys:           "1.0.0;TBD;20.83",
+		Used_cpu_user:          "1.0.0;TBD;3.02",
+		Used_cpu_sys_children:  "1.0.0;TBD;0.00",
+		Used_cpu_user_children: "1.0.0;TBD;0.00",
+	},
+	CommandStatsVersion: CommandStatsVersion{
+		Cmdstat_info: "1.0.0;TBD;calls=3,usec=181,usec_per_call=60.33",
+	},
+	ClusterVersion: ClusterVersion{
+		Cluster_enabled: "1.0.0;TBD;0",
+	},
+	KeyspaceVersion:         KeyspaceVersion{},
+	ConnectedClientsVersion: ConnectedClientsVersion{},
+}


### PR DESCRIPTION
@nl5887 @CapacitorSet    Can I have your opinion/advices ?

### Theory:
The fields of an INFO command are not the same depending on which version is implemented, the newest versions having more fields.

Every field of INFO cmd therefore has a "release version",= the first version where the field appears. 
e.g. _Atomicvar_api_ appears for the first time in 4.0.0

The goal is to compare release version with the personal version implemented by the user (or the default version)

If release version is older, we must add the field in INFO command. If newer, not add.
e.g. If user wrote in config file a redis version of 3.2.1, _Atomicvar_api_ must not appear.  
 



### Practical:
One struct, RedisDefault, with every field possible, each with value == [ a "release version", a regex fonction [=>Optional] and a default value ]

We take the personal version (implemented by user in config file or default value).
For every field of RedisDefault, we check if the "release version" is older than the personal version. 
If yes, we change the value by the one implemented by user in config file or default value.
If no, we change the value by "__".

When info command is send, we "write" only the fields where the value != "__"


### Optional:
We can check every field with regex (e.g. version must be [int.int.ints]). Also useful if some fields have consequences on other fields:
If connected_clients != 0, we need to add some id clients. 



### Questions:
- Not sure a struct is adapted in this case.
- Maybe too long to "write" the struct every time it's needed.
- Is regex useful? Or do we consider that the user knows what he is doing?

