### PR TITLE
services: redis: fix upper/lower commands/arguments

### DIFF
--- a/services/redis/commands.go
+++ b/services/redis/commands.go
@@ -32,6 +32,7 @@ package redis
 
 import (
 	"fmt"
+	"strings"
 )
 
 type cmd func(*redisService, []interface{}) (string, bool)
@@ -65,6 +66,7 @@ func (s *redisService) infoCmd(args []interface{}) (string, bool) {
 		if !success {
 			return "Expected string argument, got something else", false
 		}
+		word = strings.ToLower(word)
 		if fn, ok := mapInfoCmds[word]; ok {
 			return fmt.Sprintf(lenMsg(), len(fn(s)), fn(s)), false
 		} else if word == "default" {

--- a/services/redis/redis_handler.go
+++ b/services/redis/redis_handler.go
@@ -40,8 +40,8 @@ import (
  */
 func (s *redisService) REDISHandler(command string, args []interface{}) (string, bool) {
 	// Convert the command to lowercase
-	command = strings.ToLower(command)
-	if fn, ok := mapCmds[command]; ok {
+	cmd := strings.ToLower(command)
+	if fn, ok := mapCmds[cmd]; ok {
 		return fn(s, args)
 	} else {
 		return fmt.Sprintf(errorMsg("unknown"), command), false


### PR DESCRIPTION
Handle requests like "aBc" (  (error) ERR unknown command 'aBc' ) or "info CPU" 
