### PR TITLE
services/ssh: changed error message on privatekey not present in DB to a Debug message

### DIFF
--- a/services/ssh/storage.go
+++ b/services/ssh/storage.go
@@ -51,8 +51,8 @@ type sshStorage struct {
 func (s *sshStorage) PrivateKey() *privateKey {
 	if data, err := s.Get("private-key"); err == nil {
 		return PrivateKey(data)
-	} else if err != nil {
-		log.Errorf("Could not load private key: %s", err.Error())
+	} else {
+		log.Debugf("Could not load private-key: %s", err.Error())
 	}
 
 	if data, err := generateKey(); err != nil {


### PR DESCRIPTION
This is not an error if DB is new. It will create a new one if there is none.