### PR TITLE
honeytrap: remove redundant Gopkg constraints

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,7 +34,14 @@
 [[projects]]
   branch = "master"
   name = "github.com/dgraph-io/badger"
-  packages = [".","options","protos","skl","table","y"]
+  packages = [
+    ".",
+    "options",
+    "protos",
+    "skl",
+    "table",
+    "y"
+  ]
   revision = "94594b20babfa448fdf604b6b58b94b14b2650d9"
 
 [[projects]]
@@ -105,14 +112,38 @@
 
 [[projects]]
   name = "github.com/google/gopacket"
-  packages = [".","layers","pcap","pcapgo"]
+  packages = [
+    ".",
+    "layers",
+    "pcap",
+    "pcapgo"
+  ]
   revision = "11c65f1ca9081dfea43b4f9643f5c155583b73ba"
   version = "v1.1.14"
 
 [[projects]]
   branch = "master"
   name = "github.com/google/netstack"
-  packages = ["ilist","sleep","tcpip","tcpip/buffer","tcpip/header","tcpip/link/fdbased","tcpip/link/rawfile","tcpip/link/tun","tcpip/network/fragmentation","tcpip/network/hash","tcpip/network/ipv4","tcpip/network/ipv6","tcpip/ports","tcpip/seqnum","tcpip/stack","tcpip/transport/tcp","tmutex","waiter"]
+  packages = [
+    "ilist",
+    "sleep",
+    "tcpip",
+    "tcpip/buffer",
+    "tcpip/header",
+    "tcpip/link/fdbased",
+    "tcpip/link/rawfile",
+    "tcpip/link/tun",
+    "tcpip/network/fragmentation",
+    "tcpip/network/hash",
+    "tcpip/network/ipv4",
+    "tcpip/network/ipv6",
+    "tcpip/ports",
+    "tcpip/seqnum",
+    "tcpip/stack",
+    "tcpip/transport/tcp",
+    "tmutex",
+    "waiter"
+  ]
   revision = "edcfca33ca347f59a1393986a5d216a5f183ae28"
 
 [[projects]]
@@ -142,7 +173,12 @@
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
-  packages = [".","buffer","jlexer","jwriter"]
+  packages = [
+    ".",
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
@@ -156,6 +192,12 @@
   packages = ["."]
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mattn/go-pkg-xmlx"
+  packages = ["."]
+  revision = "db53493302d1dfcc6b9f16016e3c43cedaf5213d"
 
 [[projects]]
   name = "github.com/miekg/dns"
@@ -244,13 +286,30 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","internal/chacha20","poly1305","ssh","ssh/terminal"]
+  packages = [
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "internal/chacha20",
+    "poly1305",
+    "ssh",
+    "ssh/terminal"
+  ]
   revision = "8c653846df49742c4c85ec37e5d9f8d3ba657895"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["bpf","context","internal/iana","internal/socket","internal/timeseries","ipv4","ipv6","trace"]
+  packages = [
+    "bpf",
+    "context",
+    "internal/iana",
+    "internal/socket",
+    "internal/timeseries",
+    "ipv4",
+    "ipv6",
+    "trace"
+  ]
   revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
 
 [[projects]]
@@ -262,7 +321,11 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/registry"]
+  packages = [
+    "unix",
+    "windows",
+    "windows/registry"
+  ]
   revision = "f6cff0780e542efa0c8e864dc8fa522808f6a598"
 
 [[projects]]
@@ -273,7 +336,11 @@
 
 [[projects]]
   name = "gopkg.in/olivere/elastic.v5"
-  packages = [".","config","uritemplates"]
+  packages = [
+    ".",
+    "config",
+    "uritemplates"
+  ]
   revision = "02f6a01dc7f7fd2d65e89121e881aae3ba577a9a"
   version = "v5.0.65"
 
@@ -286,6 +353,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c4b72c7a989147e490f1e5e0f5268aabf7cfe16299404267990e9c645d78ce16"
+  inputs-digest = "841e1fd95088fb424ac9be3cb501d3fdaf602e344f44de6dd237bf12ff9442e8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -111,18 +111,6 @@
   name = "github.com/honeytrap/honeytrap-web"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/honeytrap/namecon"
-
-[[constraint]]
-  name = "github.com/imdario/mergo"
-  version = "0.2.2"
-
-[[constraint]]
-  name = "github.com/minio/cli"
-  version = "1.3.0"
-
-[[constraint]]
   name = "github.com/op/go-logging"
   version = "1.0.0"
 


### PR DESCRIPTION
Removes unused constraints from Gopkg.toml, per `go dep`'s warning.

Note that this also removes the need for https://github.com/honeytrap/namecon, which I guess can be archived if no other projects use it.