### PR TITLE
Set port parsing to unsigned int for large port numbers

### DIFF
--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -267,11 +267,11 @@ func ToAddr(input string) (net.Addr, string, int, error) {
 
 	proto := parts[0]
 	portStr := parts[1]
-	portInt16, err := strconv.ParseUint(portStr, 10, 16)
+	portUint16, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		return nil, "", 0, fmt.Errorf("error parsing port value: %s", err.Error())
 	}
-	port := int(portInt16)
+	port := int(portUint16)
 	switch proto {
 	case "tcp":
 		addr, err := net.ResolveTCPAddr("tcp", ":"+portStr)

--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -267,7 +267,7 @@ func ToAddr(input string) (net.Addr, string, int, error) {
 
 	proto := parts[0]
 	portStr := parts[1]
-	portInt16, err := strconv.ParseInt(portStr, 10, 16)
+	portInt16, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		return nil, "", 0, fmt.Errorf("error parsing port value: %s", err.Error())
 	}

--- a/server/honeytrap_test.go
+++ b/server/honeytrap_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestBigPortToAddr(t *testing.T) {
+	addr, proto, port, err := ToAddr("tcp/60000")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if addr.String() != ":60000" {
+		t.Errorf("Expected :60000 but got %s", addr)
+	}
+	if proto != "tcp" {
+		t.Errorf("Expected tcp but got %s", proto)
+	}
+	if port != 60000 {
+		t.Errorf("Expected 60000 but got %d", port)
+	}
+}
+
+func TestIncorrectSeparatorToAddr(t *testing.T) {
+	_, _, _, err := ToAddr("tcp:8080")
+	if err == nil {
+		t.Errorf("No error thrown with incorrect separator")
+	}
+}
+
+
+func TestUnknownProtoToAddr(t *testing.T) {
+	_, _, _, err := ToAddr("tdp:8080")
+	if err == nil {
+		t.Errorf("No error thrown with incorrect protocol")
+	}
+}


### PR DESCRIPTION
Port numbers are unsigned and go up to 65xxx, yet the parsing in the code was signed. Resulting in an error when trying to use a port number above 32xxx. 