### PR TITLE
Fix the first start by handling missing folder creation correctly

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -110,8 +110,9 @@ func WithDataDir(s string) (OptionFn, error) {
 			if err != nil {
 				return nil, err
 			}
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 
 	return func(b *Honeytrap) error {

--- a/server/options.go
+++ b/server/options.go
@@ -103,16 +103,15 @@ func WithDataDir(s string) (OptionFn, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	_, err = os.Stat(p)
-	if err != nil {
-		if os.IsNotExist(err) {
-			err = os.Mkdir(p, 0755)
-			if err != nil {
-				return nil, err
-			}
-		} else {
+	if os.IsNotExist(err) {
+		err = os.Mkdir(p, 0755)
+		if err != nil {
 			return nil, err
 		}
+	} else if err != nil {
+		return nil, err
 	}
 
 	return func(b *Honeytrap) error {


### PR DESCRIPTION
Fixes #287 

The error should only be returned if the folder doesn't exist. When the folder is just created, the error is no longer valid and we can carry on.