### PR TITLE
config: fix parsing in WithConfig

### DIFF
--- a/server/honeytrap.go
+++ b/server/honeytrap.go
@@ -482,7 +482,7 @@ func (hc *Honeytrap) Run(ctx context.Context) {
 		// individual configuration per service
 		options := []services.ServicerFunc{
 			services.WithChannel(hc.bus),
-			services.WithConfig(s),
+			services.WithConfig(s, hc.config),
 		}
 
 		if x.Director == "" {

--- a/services/services.go
+++ b/services/services.go
@@ -101,9 +101,13 @@ func WithDirector(d director.Director) ServicerFunc {
 	}
 }
 
-func WithConfig(c toml.Primitive) ServicerFunc {
+type TomlDecoder interface {
+	PrimitiveDecode(primValue toml.Primitive, v interface{}) error
+}
+
+func WithConfig(c toml.Primitive, decoder TomlDecoder) ServicerFunc {
 	return func(s Servicer) error {
-		err := toml.PrimitiveDecode(c, s)
+		err := decoder.PrimitiveDecode(c, s)
 		return err
 	}
 }


### PR DESCRIPTION
Fixes warnings of unused keys when WithConfig is used.