### PR TITLE
services/telnet: fix wrong handling of line endings

### DIFF
--- a/services/telnet/telnet.go
+++ b/services/telnet/telnet.go
@@ -114,7 +114,7 @@ func (s *telnetService) Handle(ctx context.Context, conn net.Conn) error {
 
 	term := NewTerminal(conn, s.Prompt)
 
-	term.Write([]byte(s.MOTD))
+	term.Write([]byte(s.MOTD + "\n"))
 
 	term.SetPrompt("Username: ")
 	username, err := term.ReadLine()

--- a/services/telnet/terminal.go
+++ b/services/telnet/terminal.go
@@ -512,14 +512,7 @@ func (t *Terminal) handleKey(key rune) (line string, ok bool) {
 		t.maxLine = 0
 	case keyEnter:
 		t.moveCursorToPos(len(t.line))
-		//t.queue([]rune("\r\n"))
-		line = string(t.line)
-		ok = true
-		t.line = t.line[:0]
-		t.pos = 0
-		t.cursorX = 0
-		t.cursorY = 0
-		t.maxLine = 0
+		ok = false
 	case keyDeleteWord:
 		// Delete zero or more spaces and then one or more characters.
 		t.eraseNPreviousChars(t.countToLeftWord())


### PR DESCRIPTION
line endings `'\r\n'` were treated wrong `'\r'` was discarded but the `'\n'` stayed in the input buffer.

Also added a newline after `motd`