### PR TITLE
config: warn if no logging backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/op/go-logging"
+	"fmt"
 )
 
 var log = logging.MustGetLogger("honeytrap:config")
@@ -80,7 +81,10 @@ func (c *Config) Load(r io.Reader) error {
 	}
 	c.MetaData = md
 
-	logBackends := []logging.Backend{}
+	if len(c.Logging) == 0 {
+		fmt.Println("Warning: no logging backends configured. Add one to view log messages.")
+	}
+	var logBackends []logging.Backend
 	for _, log := range c.Logging {
 		var err error
 


### PR DESCRIPTION
While writing a config from scratch, I forgot to add a `[[logging]]` section, and was rather puzzled as to why Honeytrap seemed not to start. I think this may occur to other people, so I added a warning when no logging backend is configured.