### PR TITLE
SMTPS

### DIFF
--- a/services/smtp/conn.go
+++ b/services/smtp/conn.go
@@ -213,6 +213,12 @@ func loopState(c *conn) stateFn {
 		c.PrintfLine("250 Ok")
 		return mailFromState
 	} else if isCommand(line, "STARTTLS") {
+		// with implicit tls there is no starttls command
+		// no tlsconfig implies no starttls
+		if c.server.implicitTLS || c.server.tlsConfig == nil {
+			return unrecognizedState
+		}
+
 		c.PrintfLine("220 Ready to start TLS")
 
 		if c.server.tlsConfig == nil {
@@ -289,7 +295,7 @@ func helloState(c *conn) stateFn {
 		c.PrintfLine("250-SIZE 35882577")
 		c.PrintfLine("250-8BITMIME")
 
-		if c.server.tlsConfig != nil {
+		if c.server.tlsConfig != nil || !c.server.implicitTLS {
 			c.PrintfLine("250-STARTTLS")
 		}
 

--- a/services/smtp/server.go
+++ b/services/smtp/server.go
@@ -73,11 +73,11 @@ func (mux *ServeMux) Serve(msg Message) error {
 }
 
 type Server struct {
-	Banner string
-
+	Banner  string
 	Handler Handler
 
-	tlsConfig *tls.Config
+	implicitTLS bool
+	tlsConfig   *tls.Config
 }
 
 func (s *Server) newConn(rwc net.Conn, recv chan string) *conn {

--- a/services/smtp/smtp.go
+++ b/services/smtp/smtp.go
@@ -44,7 +44,7 @@ import (
 	logging "github.com/op/go-logging"
 )
 
-const readDeadline = 5 // connection deadline in minutes
+const readDeadline = 10 // connection deadline in minutes
 
 var (
 	_   = services.Register("smtp", SMTP)


### PR DESCRIPTION
Added a config switch `implicit_tls={true, false}` 
When set to `true` it will only accept tls connections.
standard port for SMTPS is 465

See config options in `smtp.go`