### PR TITLE
Add option to skip certificate validation in lumberjack pusher

### DIFF
--- a/pushers/lumberjack/config.go
+++ b/pushers/lumberjack/config.go
@@ -19,5 +19,6 @@ type Config struct {
 	Interval         int    `toml:"sync_interval"`
 	CompressionLevel int    `toml:"compression_level"`
 	Secure           bool   `toml:"tls"`
+	NoVerify         bool   `toml:"no-verify"`
 	Index            string `toml:"index"`
 }

--- a/pushers/lumberjack/lumberjack.go
+++ b/pushers/lumberjack/lumberjack.go
@@ -57,10 +57,14 @@ func (b Backend) run() {
 		}
 
 		if b.Secure {
+			var tlsConn *tls.Conn
 			host, _, _ := net.SplitHostPort(b.URL)
-			tlsConn := tls.Client(conn, &tls.Config{
-				ServerName: host,
-			})
+
+			if b.NoVerify {
+				tlsConn = tls.Client(conn, &tls.Config{InsecureSkipVerify: true, ServerName: host,})
+			} else {
+				tlsConn = tls.Client(conn, &tls.Config{ServerName: host,})
+			}
 
 			if err := tlsConn.Handshake(); err != nil {
 				return err


### PR DESCRIPTION
Setting the `no-verify` option in the `config.toml` will result in the lumberjack pusher not validating the server certificate. This flag only needs to be set when `tls=true` is specified as well.