### PR TITLE
Remove index and compression level configuration in lumberjack pusher

### DIFF
--- a/pushers/lumberjack/config.go
+++ b/pushers/lumberjack/config.go
@@ -17,7 +17,5 @@ package lumberjack
 type Config struct {
 	URL              string `toml:"url"`
 	Interval         int    `toml:"sync_interval"`
-	CompressionLevel int    `toml:"compression_level"`
 	Secure           bool   `toml:"tls"`
-	Index            string `toml:"index"`
 }

--- a/pushers/lumberjack/lumberjack.go
+++ b/pushers/lumberjack/lumberjack.go
@@ -97,10 +97,6 @@ func (b Backend) run() {
 					continue
 				}
 
-				evt.Store("beat", map[string]interface{}{
-					"name": "honeytrap",
-				})
-
 				s = append(s, evt)
 
 				if len(s) < 10 {

--- a/pushers/lumberjack/lumberjack.go
+++ b/pushers/lumberjack/lumberjack.go
@@ -73,7 +73,7 @@ func (b Backend) run() {
 		}
 
 		// Create new lumberjack client for protocol encoding
-		client, err := lumberClient.NewWithConn(conn, lumberClient.CompressionLevel(b.CompressionLevel))
+		client, err := lumberClient.NewWithConn(conn)
 		if err != nil {
 			log.Errorf("lumberjack connection failed: %v", err)
 			return err
@@ -96,10 +96,6 @@ func (b Backend) run() {
 				if category == "heartbeat" {
 					continue
 				}
-
-				evt.Store("@metadata", map[string]interface{}{
-					"beat": b.Index,
-				})
 
 				evt.Store("beat", map[string]interface{}{
 					"name": "honeytrap",


### PR DESCRIPTION
- Remove compression level configuration in lumberjack pusher as the impact is negligible with honeytrap message sizes.
- Remove the addition of the @metadata field in results.