### PR TITLE
Fixing JA3 Fingerprint

### DIFF
--- a/services/ja3/crypto/tls/common.go
+++ b/services/ja3/crypto/tls/common.go
@@ -304,6 +304,10 @@ func (c *ClientHelloInfo) JA3() string {
 
 	vals := []string{}
 	for _, v := range c.CipherSuites {
+		if _, ok := greaseTable[v]; ok {
+			continue
+		}
+
 		vals = append(vals, fmt.Sprintf("%d", v))
 	}
 

--- a/services/ja3/crypto/tls/common.go
+++ b/services/ja3/crypto/tls/common.go
@@ -326,6 +326,9 @@ func (c *ClientHelloInfo) JA3() string {
 
 	vals = []string{}
 	for _, v := range c.SupportedCurves {
+		if _, ok := greaseTable[uint16(v)]; ok {
+			continue
+		}
 		vals = append(vals, fmt.Sprintf("%d", v))
 	}
 


### PR DESCRIPTION
As documented in section 6 (https://datatracker.ietf.org/doc/html/rfc8701) , the GREASE values also apply to "TLS Cipher Suites" and due to the fact we are filtering out GREASE values when creating JA3 fingerprints these values should be skipped when generating them.